### PR TITLE
Docs: Complete JavaDoc and OpenAPI specs

### DIFF
--- a/src/main/java/com/ecclesiaflow/business/aspect/BusinessOperationLoggingAspect.java
+++ b/src/main/java/com/ecclesiaflow/business/aspect/BusinessOperationLoggingAspect.java
@@ -49,29 +49,62 @@ import org.springframework.stereotype.Component;
 public class BusinessOperationLoggingAspect {
 
     /**
-     * Pointcut pour l'enregistrement de nouveaux membres
+     * Pointcut pour l'enregistrement de nouveaux membres.
+     * <p>
+     * Intercepte tous les appels à la méthode {@code registerMember} du service
+     * d'inscription pour auditer les créations de comptes membres.
+     * </p>
      */
     @Pointcut("execution(* com.ecclesiaflow.business.services.impl.MemberServiceImpl.registerMember(..))")
     public void memberRegistration() {}
 
     /**
-     * Pointcut pour les appels au module d'authentification
+     * Pointcut pour les appels au module d'authentification.
+     * <p>
+     * Intercepte toutes les méthodes du service d'authentification externe
+     * pour tracer les interactions inter-modules critiques.
+     * </p>
      */
     @Pointcut("execution(* com.ecclesiaflow.business.services.impl.AuthModuleService.*(..))")
     public void authModuleCalls() {}
 
     // === CONSEILS POUR L'ENREGISTREMENT DES MEMBRES ===
     
+    /**
+     * Log avant tentative d'enregistrement d'un nouveau membre.
+     * <p>
+     * Enregistre le début du processus d'inscription pour audit et traçabilité.
+     * </p>
+     * 
+     * @param joinPoint point de jonction contenant les détails de l'appel
+     */
     @Before("memberRegistration()")
     public void logBeforeMemberRegistration(JoinPoint joinPoint) {
         log.info("BUSINESS: Tentative d'enregistrement d'un nouveau membre");
     }
 
+    /**
+     * Log après enregistrement réussi d'un nouveau membre.
+     * <p>
+     * Confirme la création réussie du compte membre pour audit de sécurité.
+     * </p>
+     * 
+     * @param joinPoint point de jonction contenant les détails de l'appel
+     */
     @AfterReturning("memberRegistration()")
     public void logAfterSuccessfulRegistration(JoinPoint joinPoint) {
         log.info("BUSINESS: Nouveau membre enregistré avec succès");
     }
 
+    /**
+     * Log en cas d'échec d'enregistrement d'un membre.
+     * <p>
+     * Enregistre les erreurs d'inscription pour analyse et debugging.
+     * </p>
+     * 
+     * @param joinPoint point de jonction contenant les détails de l'appel
+     * @param exception l'exception qui a causé l'échec
+     */
     @AfterThrowing(pointcut = "memberRegistration()", throwing = "exception")
     public void logFailedRegistration(JoinPoint joinPoint, Throwable exception) {
         log.warn("BUSINESS: Échec de l'enregistrement du membre - {}", exception.getMessage());
@@ -79,12 +112,29 @@ public class BusinessOperationLoggingAspect {
 
     // === CONSEILS POUR LES APPELS AU MODULE D'AUTHENTIFICATION ===
     
+    /**
+     * Log avant appel au module d'authentification.
+     * <p>
+     * Trace les appels inter-modules pour debugging et monitoring des intégrations.
+     * </p>
+     * 
+     * @param joinPoint point de jonction contenant les détails de l'appel
+     */
     @Before("authModuleCalls()")
     public void logBeforeAuthModuleCall(JoinPoint joinPoint) {
         String methodName = joinPoint.getSignature().getName();
         log.debug("AUTH MODULE: Appel à {} avec arguments: {}", methodName, joinPoint.getArgs());
     }
 
+    /**
+     * Log après appel réussi au module d'authentification.
+     * <p>
+     * Confirme le succès des opérations d'authentification pour audit.
+     * </p>
+     * 
+     * @param joinPoint point de jonction contenant les détails de l'appel
+     * @param result le résultat retourné par la méthode (peut être null)
+     */
     @AfterReturning(pointcut = "authModuleCalls()", returning = "result")
     public void logAfterSuccessfulAuthModuleCall(JoinPoint joinPoint, Object result) {
         String methodName = joinPoint.getSignature().getName();
@@ -95,6 +145,15 @@ public class BusinessOperationLoggingAspect {
         }
     }
 
+    /**
+     * Log en cas d'erreur lors d'appel au module d'authentification.
+     * <p>
+     * Enregistre les échecs d'intégration pour diagnostic et alerting.
+     * </p>
+     * 
+     * @param joinPoint point de jonction contenant les détails de l'appel
+     * @param exception l'exception qui a causé l'échec
+     */
     @AfterThrowing(pointcut = "authModuleCalls()", throwing = "exception")
     public void logAuthModuleError(JoinPoint joinPoint, Throwable exception) {
         String methodName = joinPoint.getSignature().getName();

--- a/src/main/java/com/ecclesiaflow/business/domain/MembershipConfirmation.java
+++ b/src/main/java/com/ecclesiaflow/business/domain/MembershipConfirmation.java
@@ -4,14 +4,67 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.util.UUID;
+import com.ecclesiaflow.business.services.MemberConfirmationService;
 
 /**
- * Objet métier représentant une demande de confirmation de membre
- * (sans DTO - respecte la séparation des couches)
+ * Objet métier représentant une demande de confirmation de membre EcclesiaFlow.
+ * <p>
+ * Cette classe encapsule les données nécessaires pour valider un code de confirmation
+ * dans la couche métier. Respecte la séparation des couches en évitant l'utilisation
+ * directe des DTOs web dans les services métier.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Objet métier - Modèle de confirmation des membres</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Encapsulation des données de validation de confirmation</li>
+ *   <li>Liaison entre l'identifiant du membre et son code de confirmation</li>
+ *   <li>Séparation entre couche web (DTOs) et couche métier</li>
+ *   <li>Support de la validation métier des confirmations</li>
+ * </ul>
+ * 
+ * <p><strong>Flux architectural :</strong></p>
+ * <ol>
+ *   <li>DTO web (ConfirmationRequest) → Mapper → MembershipConfirmation</li>
+ *   <li>MembershipConfirmation → Service de confirmation → Validation et traitement</li>
+ *   <li>Pas de DTOs dans les services pour respecter la séparation des couches</li>
+ * </ol>
+ * 
+ * <p><strong>Cas d'utilisation :</strong></p>
+ * <ul>
+ *   <li>Confirmation initiale d'inscription avec code reçu par email</li>
+ *   <li>Validation de codes de confirmation renvoyés</li>
+ *   <li>Vérification de l'association membre-code avant activation</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, validation métier, construction flexible.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see MemberConfirmationService
+ * @see MembershipConfirmationResult
  */
 @Data
 @Builder
 public class MembershipConfirmation {
+    /**
+     * Identifiant unique du membre à confirmer.
+     * <p>
+     * UUID du membre qui tente de confirmer son compte.
+     * Doit correspondre à un membre existant dans la base de données
+     * avec un statut de confirmation en attente.
+     * </p>
+     */
     private UUID memberId;
+    
+    /**
+     * Code de confirmation à 6 chiffres saisi par le membre.
+     * <p>
+     * Code numérique que le membre a reçu par email et qu'il
+     * saisit pour confirmer son adresse email. Doit correspondre
+     * exactement au code stocké en base et ne pas avoir expiré.
+     * </p>
+     */
     private String confirmationCode;
 }

--- a/src/main/java/com/ecclesiaflow/business/domain/MembershipConfirmationResult.java
+++ b/src/main/java/com/ecclesiaflow/business/domain/MembershipConfirmationResult.java
@@ -2,10 +2,46 @@ package com.ecclesiaflow.business.domain;
 
 import lombok.Builder;
 import lombok.Data;
+import com.ecclesiaflow.business.services.MemberConfirmationService;
 
 /**
- * Objet métier représentant le résultat d'une confirmation de membre
- * (sans DTO de réponse - respecte la séparation des couches)
+ * Objet métier représentant le résultat d'une confirmation de membre EcclesiaFlow.
+ * <p>
+ * Cette classe encapsule les données de réponse après une confirmation réussie
+ * dans la couche métier. Respecte la séparation des couches en évitant l'utilisation
+ * directe des DTOs de réponse web dans les services métier.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Objet métier - Résultat de confirmation des membres</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Encapsulation du résultat de confirmation réussie</li>
+ *   <li>Transport du token temporaire pour définition du mot de passe</li>
+ *   <li>Information sur l'expiration du token temporaire</li>
+ *   <li>Séparation entre couche métier et couche web (DTOs)</li>
+ * </ul>
+ * 
+ * <p><strong>Flux architectural :</strong></p>
+ * <ol>
+ *   <li>Service de confirmation → MembershipConfirmationResult</li>
+ *   <li>MembershipConfirmationResult → Mapper → DTO de réponse (ConfirmationResponse)</li>
+ *   <li>Pas de DTOs dans les services pour respecter la séparation des couches</li>
+ * </ol>
+ * 
+ * <p><strong>Contenu typique :</strong></p>
+ * <ul>
+ *   <li>Message de succès pour l'utilisateur</li>
+ *   <li>Token temporaire pour accéder à la définition du mot de passe</li>
+ *   <li>Durée de validité du token (généralement 1 heure)</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, construction flexible, données cohérentes.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see MemberConfirmationService
+ * @see MembershipConfirmation
  */
 @Data
 @Builder

--- a/src/main/java/com/ecclesiaflow/business/domain/MembershipUpdate.java
+++ b/src/main/java/com/ecclesiaflow/business/domain/MembershipUpdate.java
@@ -2,52 +2,100 @@ package com.ecclesiaflow.business.domain;
 
 import lombok.Builder;
 import lombok.Data;
+import com.ecclesiaflow.business.services.MemberService;
+import com.ecclesiaflow.io.entities.Member;
 
 import java.util.UUID;
 
 /**
- * Objet métier représentant une demande de modification d'un membre.
+ * Objet métier représentant une demande de modification d'un membre EcclesiaFlow.
  * <p>
- * Utilisé dans la couche business pour encapsuler les données de modification
- * d'un membre sans dépendre des DTOs de la couche web.
+ * Cette classe encapsule les données de mise à jour d'un profil membre existant.
+ * Utilise le pattern Builder pour une construction flexible et supporte les
+ * mises à jour partielles (champs optionnels null = pas de modification).
  * </p>
  * 
- * <p><strong>Architecture :</strong></p>
+ * <p><strong>Rôle architectural :</strong> Objet métier - Modèle de mise à jour des membres</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
  * <ul>
- *   <li>DTO web → Mapper → Objet métier → Service</li>
- *   <li>Séparation stricte entre couches web et business</li>
- *   <li>Pas de DTOs dans les services métier</li>
+ *   <li>Encapsulation des données de modification de profil</li>
+ *   <li>Support des mises à jour partielles (champs optionnels)</li>
+ *   <li>Séparation entre couche web (DTOs) et couche métier</li>
+ *   <li>Validation métier des modifications demandées</li>
  * </ul>
+ * 
+ * <p><strong>Flux architectural :</strong></p>
+ * <ol>
+ *   <li>DTO web (UpdateMemberRequest) → Mapper → MembershipUpdate</li>
+ *   <li>MembershipUpdate → Service métier → Validation et persistance</li>
+ *   <li>Pas de DTOs dans les services pour respecter la séparation des couches</li>
+ * </ol>
+ * 
+ * <p><strong>Stratégie de mise à jour :</strong></p>
+ * <ul>
+ *   <li>Champs null = pas de modification (conserve la valeur existante)</li>
+ *   <li>Champs non-null = nouvelle valeur à appliquer</li>
+ *   <li>memberId obligatoire pour identifier le membre à modifier</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, validation métier, construction flexible.</p>
  * 
  * @author EcclesiaFlow Team
  * @since 1.0.0
+ * @see Member
+ * @see MemberService
  */
 @Data
 @Builder
 public class MembershipUpdate {
     
     /**
-     * ID du membre à modifier
+     * Identifiant unique du membre à modifier.
+     * <p>
+     * UUID obligatoire pour identifier de manière unique le membre
+     * dont le profil doit être mis à jour. Doit correspondre à un
+     * membre existant et confirmé dans la base de données.
+     * </p>
      */
     private UUID memberId;
     
     /**
-     * Nouveau prénom (optionnel)
+     * Nouveau prénom du membre (optionnel).
+     * <p>
+     * Si non-null, remplace le prénom existant du membre.
+     * Si null, le prénom actuel est conservé sans modification.
+     * </p>
      */
     private String firstName;
     
     /**
-     * Nouveau nom de famille (optionnel)
+     * Nouveau nom de famille du membre (optionnel).
+     * <p>
+     * Si non-null, remplace le nom de famille existant du membre.
+     * Si null, le nom de famille actuel est conservé sans modification.
+     * </p>
      */
     private String lastName;
     
     /**
-     * Nouvelle adresse (optionnel)
+     * Nouvelle adresse physique du membre (optionnel).
+     * <p>
+     * Si non-null, remplace l'adresse existante du membre.
+     * Si null, l'adresse actuelle est conservée sans modification.
+     * Peut être une chaîne vide pour effacer l'adresse existante.
+     * </p>
      */
     private String address;
     
     /**
-     * Nouvel email (optionnel)
+     * Nouvelle adresse email du membre (optionnel).
+     * <p>
+     * Si non-null, remplace l'email existant du membre.
+     * Si null, l'email actuel est conservé sans modification.
+     * <strong>Attention :</strong> La modification de l'email peut nécessiter
+     * une nouvelle confirmation selon les règles métier.
+     * </p>
      */
     private String email;
 }

--- a/src/main/java/com/ecclesiaflow/business/mappers/ConfirmationRequestMapper.java
+++ b/src/main/java/com/ecclesiaflow/business/mappers/ConfirmationRequestMapper.java
@@ -7,14 +7,52 @@ import org.springframework.stereotype.Component;
 import java.util.UUID;
 
 /**
- * Mapper pour transformer les DTOs de confirmation en objets métier
- * Respecte la séparation des couches : DTOs web → mapper → objets métier
+ * Mapper pour la transformation des DTOs de confirmation en objets métier.
+ * <p>
+ * Cette classe gère la conversion des requêtes de confirmation provenant de la couche web
+ * vers les objets métier utilisés par les services. Implémente le pattern de mapping
+ * avec gestion des cas limites (requêtes nulles ou incomplètes).
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Mapper - Conversion DTO vers objet métier</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Transformation des DTOs de confirmation en objets métier</li>
+ *   <li>Combinaison des données de requête avec l'identifiant membre</li>
+ *   <li>Gestion des cas limites (requêtes nulles)</li>
+ *   <li>Séparation claire entre couche web et couche métier</li>
+ * </ul>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Transformation des requêtes de confirmation de compte</li>
+ *   <li>Préparation des données pour le service de confirmation</li>
+ *   <li>Orchestration par les contrôleurs de confirmation</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe (bean Spring), gestion des cas limites.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
  */
 @Component
 public class ConfirmationRequestMapper {
 
     /**
-     * Transforme un DTO de confirmation et un memberId en objet métier
+     * Transforme un DTO de confirmation et un identifiant membre en objet métier.
+     * <p>
+     * Cette méthode combine les données de la requête de confirmation avec
+     * l'identifiant du membre pour créer un objet métier complet. Gère le cas
+     * où la requête est nulle en créant un objet avec un code vide.
+     * </p>
+     * 
+     * @param memberId l'identifiant unique du membre à confirmer, non null
+     * @param request la requête de confirmation contenant le code, peut être null
+     * @return un {@link MembershipConfirmation} prêt pour le traitement métier
+     * @throws IllegalArgumentException si memberId est null
+     * 
+     * @implNote Utilise le pattern Builder pour la construction de l'objet métier.
      */
     public MembershipConfirmation fromConfirmationRequest(UUID memberId, ConfirmationRequest request) {
         if (request == null) {

--- a/src/main/java/com/ecclesiaflow/business/services/EmailService.java
+++ b/src/main/java/com/ecclesiaflow/business/services/EmailService.java
@@ -4,8 +4,97 @@ import com.ecclesiaflow.web.exception.ConfirmationEmailException;
 import com.ecclesiaflow.web.exception.PasswordResetEmailException;
 import com.ecclesiaflow.web.exception.WelcomeEmailException;
 
+/**
+ * Service de domaine pour la gestion des communications email dans EcclesiaFlow.
+ * <p>
+ * Cette interface définit l'ensemble des opérations d'envoi d'emails
+ * liées au cycle de vie des membres : confirmation, bienvenue, et récupération
+ * de mot de passe. Centralise toute la logique de communication email.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Service de domaine - Communication email</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Envoi d'emails de confirmation d'inscription</li>
+ *   <li>Envoi d'emails de bienvenue après confirmation</li>
+ *   <li>Envoi d'emails de récupération de mot de passe</li>
+ *   <li>Gestion des templates et du contenu des emails</li>
+ *   <li>Gestion des erreurs d'envoi et retry logic</li>
+ * </ul>
+ * 
+ * <p><strong>Dépendances critiques :</strong></p>
+ * <ul>
+ *   <li>Configuration SMTP (Gmail App Password)</li>
+ *   <li>Templates d'emails (HTML/Text)</li>
+ *   <li>Service de logging pour traçabilité</li>
+ * </ul>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Envoi automatique lors de l'inscription d'un nouveau membre</li>
+ *   <li>Envoi de bienvenue après confirmation réussie</li>
+ *   <li>Processus de récupération de mot de passe oublié</li>
+ *   <li>Notifications administratives aux membres</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, gestion d'erreurs robuste, logging complet.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ */
 public interface EmailService {
+    
+    /**
+     * Envoie un email contenant le code de confirmation d'inscription.
+     * <p>
+     * Cette méthode génère et envoie un email personnalisé contenant
+     * le code de confirmation nécessaire pour activer le compte membre.
+     * L'email utilise un template HTML avec le nom du membre et le code.
+     * </p>
+     * 
+     * @param email l'adresse email du destinataire, non null et valide
+     * @param code le code de confirmation à 6 chiffres, non null
+     * @param firstName le prénom du membre pour personnalisation, non null
+     * @throws ConfirmationEmailException si l'envoi échoue (SMTP, réseau, etc.)
+     * @throws IllegalArgumentException si un paramètre est null ou invalide
+     * 
+     * @implNote Utilise le template 'confirmation-email.html' avec retry automatique.
+     */
     void sendConfirmationCode(String email, String code, String firstName) throws ConfirmationEmailException;
+    
+    /**
+     * Envoie un email de bienvenue après confirmation réussie du compte.
+     * <p>
+     * Cette méthode envoie un email de bienvenue personnalisé pour féliciter
+     * le nouveau membre et lui fournir les informations de première connexion.
+     * Marque la fin du processus d'inscription.
+     * </p>
+     * 
+     * @param email l'adresse email du nouveau membre confirmé, non null et valide
+     * @param firstName le prénom du membre pour personnalisation, non null
+     * @throws WelcomeEmailException si l'envoi échoue (SMTP, réseau, etc.)
+     * @throws IllegalArgumentException si un paramètre est null ou invalide
+     * 
+     * @implNote Utilise le template 'welcome-email.html' avec informations de connexion.
+     */
     void sendWelcomeEmail(String email, String firstName) throws WelcomeEmailException;
+    
+    /**
+     * Envoie un email de récupération de mot de passe avec lien sécurisé.
+     * <p>
+     * Cette méthode génère et envoie un email contenant un lien sécurisé
+     * permettant au membre de réinitialiser son mot de passe. Le lien
+     * contient un token temporaire avec expiration.
+     * </p>
+     * 
+     * @param email l'adresse email du membre, non null et valide
+     * @param resetLink le lien sécurisé de réinitialisation avec token, non null
+     * @param firstName le prénom du membre pour personnalisation, non null
+     * @throws PasswordResetEmailException si l'envoi échoue (SMTP, réseau, etc.)
+     * @throws IllegalArgumentException si un paramètre est null ou invalide
+     * 
+     * @implNote Utilise le template 'password-reset-email.html' avec lien temporaire.
+     */
     void sendPasswordResetEmail(String email, String resetLink, String firstName) throws PasswordResetEmailException;
 }

--- a/src/main/java/com/ecclesiaflow/business/services/MemberConfirmationService.java
+++ b/src/main/java/com/ecclesiaflow/business/services/MemberConfirmationService.java
@@ -1,12 +1,86 @@
 package com.ecclesiaflow.business.services;
 
-
 import com.ecclesiaflow.business.domain.MembershipConfirmationResult;
 import com.ecclesiaflow.business.domain.MembershipConfirmation;
 
 import java.util.UUID;
 
+/**
+ * Service de domaine pour la gestion du processus de confirmation des membres EcclesiaFlow.
+ * <p>
+ * Cette interface définit les opérations liées au processus de confirmation
+ * des comptes membres : validation des codes, génération et envoi des codes,
+ * et gestion du statut de confirmation. Complète le processus d'inscription.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Service de domaine - Confirmation des membres</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Validation des codes de confirmation saisis par les membres</li>
+ *   <li>Génération de nouveaux codes de confirmation</li>
+ *   <li>Gestion de l'expiration des codes de confirmation</li>
+ *   <li>Mise à jour du statut de confirmation des membres</li>
+ *   <li>Orchestration avec le service d'email pour l'envoi des codes</li>
+ * </ul>
+ * 
+ * <p><strong>Dépendances critiques :</strong></p>
+ * <ul>
+ *   <li>{@link com.ecclesiaflow.io.repository.MemberRepository} - Accès aux données membres</li>
+ *   <li>{@link com.ecclesiaflow.io.repository.MemberConfirmationRepository} - Gestion des codes</li>
+ *   <li>{@link EmailService} - Envoi des emails de confirmation</li>
+ * </ul>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Confirmation d'un compte après inscription</li>
+ *   <li>Renvoi d'un code de confirmation expiré</li>
+ *   <li>Validation des tentatives de confirmation multiples</li>
+ *   <li>Gestion des codes expirés ou invalides</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, transactionnel, sécurisé (codes à usage unique).</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ */
 public interface MemberConfirmationService {
+    
+    /**
+     * Confirme un membre en validant son code de confirmation.
+     * <p>
+     * Cette méthode valide le code de confirmation fourni par le membre,
+     * vérifie sa validité et son expiration, puis met à jour le statut
+     * du membre à "confirmé". Génère un token temporaire pour la définition
+     * du mot de passe.
+     * </p>
+     * 
+     * @param confirmationRequest les données de confirmation (memberId, code), non null
+     * @return le résultat de la confirmation avec token temporaire et statut
+     * @throws com.ecclesiaflow.web.exception.MemberNotFoundException si le membre n'existe pas
+     * @throws com.ecclesiaflow.web.exception.InvalidConfirmationCodeException si le code est invalide ou expiré
+     * @throws com.ecclesiaflow.web.exception.MemberAlreadyConfirmedException si le membre est déjà confirmé
+     * @throws IllegalArgumentException si confirmationRequest est null ou invalide
+     * 
+     * @implNote Opération transactionnelle avec mise à jour du statut et invalidation du code.
+     */
     MembershipConfirmationResult confirmMember(MembershipConfirmation confirmationRequest);
+    
+    /**
+     * Génère et envoie un nouveau code de confirmation pour un membre.
+     * <p>
+     * Cette méthode génère un nouveau code de confirmation à 6 chiffres,
+     * l'associe au membre spécifié, et orchestre l'envoi de l'email
+     * de confirmation via le service d'email. Invalide les codes précédents.
+     * </p>
+     * 
+     * @param memberId l'identifiant du membre pour lequel générer un code, non null
+     * @throws com.ecclesiaflow.web.exception.MemberNotFoundException si le membre n'existe pas
+     * @throws com.ecclesiaflow.web.exception.MemberAlreadyConfirmedException si le membre est déjà confirmé
+     * @throws com.ecclesiaflow.web.exception.ConfirmationEmailException si l'envoi de l'email échoue
+     * @throws IllegalArgumentException si memberId est null
+     * 
+     * @implNote Opération transactionnelle avec génération aléatoire sécurisée et envoi email.
+     */
     void sendConfirmationCode(UUID memberId);
 }

--- a/src/main/java/com/ecclesiaflow/business/services/MemberService.java
+++ b/src/main/java/com/ecclesiaflow/business/services/MemberService.java
@@ -8,29 +8,40 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Service de domaine dédié à l'enregistrement de nouveaux membres EcclesiaFlow.
+ * Service de domaine pour la gestion complète des membres EcclesiaFlow.
  * <p>
- * Cette interface définit les opérations d'inscription et de validation des nouveaux
- * membres dans le système. Respecte le principe de responsabilité unique (SRP)
- * en se concentrant uniquement sur l'enregistrement.
+ * Cette interface définit l'ensemble des opérations de gestion des membres :
+ * inscription, validation, mise à jour, consultation et suppression.
+ * Respecte le principe de responsabilité unique (SRP) en centralisant
+ * toute la logique métier liée aux membres.
  * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Service de domaine - Gestion des membres</p>
  * 
  * <p><strong>Responsabilités principales :</strong></p>
  * <ul>
- *   <li>Validation des données d'inscription</li>
- *   <li>Encodage sécurisé des mots de passe</li>
- *   <li>Persistance des nouveaux membres</li>
- *   <li>Vérification de l'unicité des emails</li>
+ *   <li>Inscription et validation des nouveaux membres</li>
+ *   <li>Gestion du cycle de vie des comptes membres</li>
+ *   <li>Vérification de l'unicité et du statut des emails</li>
+ *   <li>Opérations CRUD sur les profils membres</li>
+ *   <li>Validation des données métier</li>
+ * </ul>
+ * 
+ * <p><strong>Dépendances critiques :</strong></p>
+ * <ul>
+ *   <li>{@link com.ecclesiaflow.io.repository.MemberRepository} - Persistance des données</li>
+ *   <li>Services de validation métier internes</li>
  * </ul>
  * 
  * <p><strong>Cas d'utilisation typiques :</strong></p>
  * <ul>
- *   <li>Inscription de nouveaux utilisateurs via formulaire web</li>
- *   <li>Création de comptes administrateurs</li>
- *   <li>Import en masse de membres</li>
+ *   <li>Inscription de nouveaux membres via formulaire web</li>
+ *   <li>Consultation et mise à jour des profils existants</li>
+ *   <li>Vérification du statut de confirmation des comptes</li>
+ *   <li>Administration des membres par les pasteurs</li>
  * </ul>
  * 
- * <p><strong>Garanties :</strong> Thread-safe, transactionnel.</p>
+ * <p><strong>Garanties :</strong> Thread-safe (stateless), transactionnel, validation métier.</p>
  * 
  * @author EcclesiaFlow Team
  * @since 1.0.0
@@ -54,20 +65,99 @@ public interface MemberService {
     Member registerMember(MembershipRegistration registration);
 
     /**
-     * Vérifie si un email est déjà utilisé
-     * @param email l'email à vérifier
-     * @return true si l'email existe déjà
+     * Vérifie si un email est déjà utilisé dans le système.
+     * <p>
+     * Cette méthode permet de valider l'unicité d'un email avant
+     * l'inscription d'un nouveau membre. Utilisée pour prévenir
+     * les doublons et assurer l'intégrité des données.
+     * </p>
+     * 
+     * @param email l'adresse email à vérifier, non null
+     * @return true si l'email existe déjà en base, false sinon
+     * @throws IllegalArgumentException si email est null ou vide
+     * 
+     * @implNote Opération de lecture optimisée (index sur email).
      */
     boolean isEmailAlreadyUsed(String email);
 
     /**
      * Vérifie si un membre avec cet email est confirmé.
-     * @param email l'email du membre à vérifier
+     * <p>
+     * Cette méthode vérifie à la fois l'existence du membre et son
+     * statut de confirmation. Utilisée par le module d'authentification
+     * pour valider les tentatives de connexion.
+     * </p>
+     * 
+     * @param email l'email du membre à vérifier, non null
      * @return true si le membre existe et est confirmé, false sinon
+     * @throws IllegalArgumentException si email est null ou vide
+     * 
+     * @implNote Opération de lecture avec jointure sur statut de confirmation.
      */
     boolean isEmailConfirmed(String email);
+    
+    /**
+     * Recherche un membre par son identifiant unique.
+     * <p>
+     * Cette méthode récupère les informations complètes d'un membre
+     * à partir de son UUID. Utilisée pour les opérations de consultation
+     * et de mise à jour des profils.
+     * </p>
+     * 
+     * @param id l'identifiant unique du membre, non null
+     * @return le membre correspondant avec toutes ses informations
+     * @throws com.ecclesiaflow.web.exception.MemberNotFoundException si aucun membre avec cet ID n'existe
+     * @throws IllegalArgumentException si id est null
+     * 
+     * @implNote Opération de lecture par clé primaire (optimisée).
+     */
     Member findById(UUID id);
+    
+    /**
+     * Met à jour les informations d'un membre existant.
+     * <p>
+     * Cette méthode applique les modifications spécifiées au profil
+     * d'un membre. Seuls les champs fournis sont mis à jour (patch partiel).
+     * L'email et le statut de confirmation ne peuvent pas être modifiés.
+     * </p>
+     * 
+     * @param updateRequest les données de mise à jour, non null
+     * @return le membre mis à jour avec les nouvelles informations
+     * @throws com.ecclesiaflow.web.exception.MemberNotFoundException si le membre n'existe pas
+     * @throws IllegalArgumentException si updateRequest est null ou invalide
+     * 
+     * @implNote Opération transactionnelle en écriture avec validation métier.
+     */
     Member updateMember(MembershipUpdate updateRequest);
+    
+    /**
+     * Supprime définitivement un membre du système.
+     * <p>
+     * Cette méthode effectue une suppression complète du membre
+     * et de toutes ses données associées. Opération irréversible
+     * réservée aux administrateurs.
+     * </p>
+     * 
+     * @param id l'identifiant du membre à supprimer, non null
+     * @throws com.ecclesiaflow.web.exception.MemberNotFoundException si le membre n'existe pas
+     * @throws IllegalArgumentException si id est null
+     * 
+     * @implNote Opération transactionnelle en écriture avec cascade sur données liées.
+     */
     void deleteMember(UUID id);
+    
+    /**
+     * Récupère la liste de tous les membres du système.
+     * <p>
+     * Cette méthode retourne tous les membres enregistrés,
+     * confirmés ou non. Utilisée pour les interfaces d'administration
+     * et les rapports. Pour les gros volumes, préférer une approche paginée.
+     * </p>
+     * 
+     * @return la liste de tous les membres, peut être vide mais jamais null
+     * 
+     * @implNote Opération de lecture potentiellement coûteuse sur gros volumes.
+     * @deprecated Utiliser une approche paginée pour les gros volumes
+     */
     List<Member> getAllMembers();
 }

--- a/src/main/java/com/ecclesiaflow/business/services/impl/AuthModuleService.java
+++ b/src/main/java/com/ecclesiaflow/business/services/impl/AuthModuleService.java
@@ -9,6 +9,53 @@ import reactor.core.publisher.Mono;
 
 import java.util.Map;
 
+/**
+ * Service d'intégration avec le module d'authentification EcclesiaFlow.
+ * <p>
+ * Cette classe fournit les opérations d'intégration avec le module d'authentification
+ * séparé : génération de tokens temporaires, définition et changement de mots de passe.
+ * Utilise WebClient pour les appels HTTP asynchrones vers le module d'auth.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Service d'intégration - Communication inter-modules</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Génération de tokens temporaires après confirmation de compte</li>
+ *   <li>Définition initiale du mot de passe avec token temporaire</li>
+ *   <li>Changement de mot de passe pour utilisateurs authentifiés</li>
+ *   <li>Gestion des erreurs de communication inter-modules</li>
+ * </ul>
+ * 
+ * <p><strong>Dépendances critiques :</strong></p>
+ * <ul>
+ *   <li>{@link WebClient} - Client HTTP réactif configuré pour le module d'auth</li>
+ *   <li>Module d'authentification EcclesiaFlow (service externe)</li>
+ * </ul>
+ * 
+ * <p><strong>Configuration :</strong></p>
+ * <ul>
+ *   <li>ecclesiaflow.auth.module.enabled - Active/désactive l'intégration</li>
+ *   <li>Configuration WebClient dans {@link com.ecclesiaflow.web.config.WebClientConfig}</li>
+ * </ul>
+ * 
+ * <p><strong>Endpoints du module d'auth :</strong></p>
+ * <ul>
+ *   <li>POST /ecclesiaflow/auth/temporary-token - Génération de token temporaire</li>
+ *   <li>POST /ecclesiaflow/auth/set-password - Définition initiale du mot de passe</li>
+ *   <li>POST /ecclesiaflow/auth/change-password - Changement de mot de passe</li>
+ * </ul>
+ * 
+ * <p><strong>Gestion d'erreurs :</strong> Mode dégradé avec valeurs de test en cas
+ * d'indisponibilité du module d'authentification.</p>
+ * 
+ * <p><strong>Garanties :</strong> Asynchrone non-bloquant, resilient aux pannes, configurable.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see WebClient
+ * @see com.ecclesiaflow.web.config.WebClientConfig
+ */
 @Service
 @RequiredArgsConstructor
 @ConditionalOnProperty(name = "ecclesiaflow.auth.module.enabled", havingValue = "true", matchIfMissing = true)
@@ -16,6 +63,20 @@ public class AuthModuleService {
 
     private final WebClient authWebClient;
 
+    /**
+     * Génère un token temporaire pour permettre la définition du mot de passe.
+     * <p>
+     * Appelle le module d'authentification pour générer un token temporaire
+     * valide 1 heure, permettant à l'utilisateur de définir son mot de passe
+     * après confirmation de son compte.
+     * </p>
+     * 
+     * @param email l'email du membre confirmé, non null
+     * @return le token temporaire généré, ou une valeur de test en cas d'erreur
+     * 
+     * @implNote En cas d'erreur de communication, retourne une valeur de test
+     *           pour permettre le développement en mode dégradé.
+     */
     public String generateTemporaryToken(String email) {
         try {
             return post("/ecclesiaflow/auth/temporary-token", Map.of("email", email))
@@ -26,6 +87,21 @@ public class AuthModuleService {
         }
     }
 
+    /**
+     * Définit le mot de passe initial d'un utilisateur avec un token temporaire.
+     * <p>
+     * Appelle le module d'authentification pour définir le mot de passe
+     * d'un utilisateur nouvellement confirmé. Nécessite un token temporaire
+     * valide obtenu après confirmation du compte.
+     * </p>
+     * 
+     * @param email l'email de l'utilisateur, non null
+     * @param password le nouveau mot de passe, non null
+     * @param temporaryToken le token temporaire valide, non null
+     * 
+     * @implNote Les erreurs sont silencieuses pour éviter d'interrompre
+     *           le flux utilisateur en cas de problème de communication.
+     */
     public void setPassword(String email, String password, String temporaryToken) {
         try {
             postVoid("/ecclesiaflow/auth/set-password", Map.of(
@@ -36,6 +112,19 @@ public class AuthModuleService {
         } catch (Exception e) {}
     }
 
+    /**
+     * Change le mot de passe d'un utilisateur authentifié.
+     * <p>
+     * Appelle le module d'authentification pour changer le mot de passe
+     * d'un utilisateur. Nécessite le mot de passe actuel pour validation.
+     * </p>
+     * 
+     * @param email l'email de l'utilisateur, non null
+     * @param currentPassword le mot de passe actuel pour validation, non null
+     * @param newPassword le nouveau mot de passe, non null
+     * 
+     * @throws RuntimeException si l'opération échoue (mot de passe incorrect, etc.)
+     */
     public void changePassword(String email, String currentPassword, String newPassword) {
         postVoid("/ecclesiaflow/auth/change-password", Map.of(
                 "email", email,
@@ -44,8 +133,19 @@ public class AuthModuleService {
         )).block();
     }
 
-    // === Utility Methods ===
+    // === Méthodes utilitaires ===
 
+    /**
+     * Effectue un appel POST vers le module d'authentification avec réponse.
+     * <p>
+     * Méthode utilitaire pour les appels HTTP POST qui attendent une réponse
+     * du module d'authentification. Gère les erreurs 4xx et 5xx automatiquement.
+     * </p>
+     * 
+     * @param path le chemin de l'endpoint (ex: "/ecclesiaflow/auth/temporary-token")
+     * @param body le corps de la requête sous forme de Map
+     * @return un Mono contenant la réponse sous forme de Map
+     */
     private Mono<Map> post(String path, Map<String, String> body) {
         return authWebClient
                 .post()
@@ -61,6 +161,17 @@ public class AuthModuleService {
                 .bodyToMono(Map.class);
     }
 
+    /**
+     * Effectue un appel POST vers le module d'authentification sans réponse attendue.
+     * <p>
+     * Méthode utilitaire pour les appels HTTP POST qui n'attendent pas de réponse
+     * spécifique du module d'authentification. Gère toutes les erreurs HTTP.
+     * </p>
+     * 
+     * @param path le chemin de l'endpoint (ex: "/ecclesiaflow/auth/set-password")
+     * @param body le corps de la requête sous forme de Map
+     * @return un Mono<Void> pour la completion de l'opération
+     */
     private Mono<Void> postVoid(String path, Map<String, String> body) {
         return authWebClient
                 .post()

--- a/src/main/java/com/ecclesiaflow/business/services/impl/EmailServiceImpl.java
+++ b/src/main/java/com/ecclesiaflow/business/services/impl/EmailServiceImpl.java
@@ -11,7 +11,47 @@ import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Value;
 
 /**
- * Implémentation du service d'envoi d'emails
+ * Implémentation complète du service d'envoi d'emails pour EcclesiaFlow.
+ * <p>
+ * Cette classe implémente l'interface {@link EmailService} et fournit toutes les
+ * fonctionnalités d'envoi d'emails : codes de confirmation, emails de bienvenue,
+ * et réinitialisation de mot de passe. Utilise Spring Mail avec JavaMailSender
+ * pour l'envoi effectif des emails.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Implémentation de service - Communication par email</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Envoi d'emails de confirmation avec codes à 6 chiffres</li>
+ *   <li>Envoi d'emails de bienvenue après confirmation</li>
+ *   <li>Envoi d'emails de réinitialisation de mot de passe</li>
+ *   <li>Construction des contenus d'emails personnalisés</li>
+ *   <li>Gestion des erreurs d'envoi avec exceptions spécifiques</li>
+ * </ul>
+ * 
+ * <p><strong>Dépendances critiques :</strong></p>
+ * <ul>
+ *   <li>{@link JavaMailSender} - Service Spring Mail pour l'envoi effectif</li>
+ *   <li>Configuration SMTP via application.properties</li>
+ * </ul>
+ * 
+ * <p><strong>Configuration requise :</strong></p>
+ * <ul>
+ *   <li>ecclesiaflow.mail.from - Adresse email expéditeur</li>
+ *   <li>ecclesiaflow.app.name - Nom de l'application dans les emails</li>
+ *   <li>Configuration SMTP (host, port, auth, etc.)</li>
+ * </ul>
+ * 
+ * <p><strong>Gestion d'erreurs :</strong> Toute erreur d'envoi est encapsulée dans
+ * des exceptions métier spécifiques pour permettre un traitement approprié.</p>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, gestion d'erreurs robuste, templates personnalisables.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see EmailService
+ * @see JavaMailSender
  */
 @Service
 @RequiredArgsConstructor
@@ -70,6 +110,18 @@ public class EmailServiceImpl implements EmailService {
         }
     }
 
+    /**
+     * Construit le contenu textuel de l'email de confirmation.
+     * <p>
+     * Génère un message personnalisé contenant le code de confirmation,
+     * les instructions d'utilisation, et la durée de validité (24h).
+     * Utilise les text blocks Java pour une meilleure lisibilité.
+     * </p>
+     * 
+     * @param code le code de confirmation à 6 chiffres, non null
+     * @param firstName le prénom du destinataire pour personnalisation, non null
+     * @return le contenu complet de l'email formaté
+     */
     private String buildConfirmationEmailText(String code, String firstName) {
         return String.format("""
                 Bonjour %s,
@@ -89,6 +141,16 @@ public class EmailServiceImpl implements EmailService {
                 """, firstName, appName, code, appName);
     }
 
+    /**
+     * Construit le contenu textuel de l'email de bienvenue.
+     * <p>
+     * Génère un message de félicitations après confirmation réussie du compte.
+     * Confirme la création du compte et encourage l'utilisation de l'application.
+     * </p>
+     * 
+     * @param firstName le prénom du nouveau membre confirmé, non null
+     * @return le contenu complet de l'email de bienvenue formaté
+     */
     private String buildWelcomeEmailText(String firstName) {
         return String.format("""
                 Bonjour %s,
@@ -102,6 +164,18 @@ public class EmailServiceImpl implements EmailService {
                 """, firstName, appName, appName);
     }
 
+    /**
+     * Construit le contenu textuel de l'email de réinitialisation de mot de passe.
+     * <p>
+     * Génère un message contenant le lien sécurisé de réinitialisation,
+     * les instructions d'utilisation, et la durée de validité (1h).
+     * Inclut des avertissements de sécurité appropriés.
+     * </p>
+     * 
+     * @param resetLink le lien sécurisé de réinitialisation, non null
+     * @param firstName le prénom du destinataire pour personnalisation, non null
+     * @return le contenu complet de l'email de réinitialisation formaté
+     */
     private String buildPasswordResetEmailText(String resetLink, String firstName) {
         return String.format("""
                 Bonjour %s,

--- a/src/main/java/com/ecclesiaflow/business/services/impl/MemberPasswordService.java
+++ b/src/main/java/com/ecclesiaflow/business/services/impl/MemberPasswordService.java
@@ -9,6 +9,46 @@ import org.springframework.stereotype.Service;
 
 import java.util.UUID;
 
+/**
+ * Service de gestion des mots de passe des membres EcclesiaFlow.
+ * <p>
+ * Cette classe orchestre les opérations liées aux mots de passe des membres
+ * en déléguant au module d'authentification via {@link AuthModuleService}.
+ * Fournit également des utilitaires pour récupérer les informations des membres.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Service orchestrateur - Gestion des mots de passe</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Définition initiale du mot de passe avec token temporaire</li>
+ *   <li>Récupération des informations membres pour les opérations de mot de passe</li>
+ *   <li>Orchestration avec le module d'authentification</li>
+ * </ul>
+ * 
+ * <p><strong>Dépendances critiques :</strong></p>
+ * <ul>
+ *   <li>{@link AuthModuleService} - Communication avec le module d'authentification</li>
+ *   <li>{@link MemberRepository} - Récupération des informations membres</li>
+ * </ul>
+ * 
+ * <p><strong>Flux typique :</strong></p>
+ * <ol>
+ *   <li>Réception de la demande de définition de mot de passe</li>
+ *   <li>Validation de l'existence du membre</li>
+ *   <li>Délégation au module d'authentification</li>
+ * </ol>
+ * 
+ * <p><strong>Note architecturale :</strong> Ce service fait partie du module membres
+ * mais délègue toute la logique d'authentification au module spécialisé.</p>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, gestion d'erreurs, séparation des responsabilités.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see AuthModuleService
+ * @see MemberRepository
+ */
 @Service
 @RequiredArgsConstructor
 public class MemberPasswordService {

--- a/src/main/java/com/ecclesiaflow/io/entities/MemberConfirmation.java
+++ b/src/main/java/com/ecclesiaflow/io/entities/MemberConfirmation.java
@@ -11,6 +11,46 @@ import org.hibernate.annotations.UuidGenerator;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Entité JPA représentant un code de confirmation de membre EcclesiaFlow.
+ * <p>
+ * Cette classe modélise les codes de confirmation temporaires envoyés aux membres
+ * pour valider leur adresse email lors de l'inscription. Gère l'expiration
+ * automatique et la validation des codes à 6 chiffres.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Entité JPA - Modèle de données des confirmations</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Stockage sécurisé des codes de confirmation temporaires</li>
+ *   <li>Gestion de l'expiration automatique des codes</li>
+ *   <li>Liaison avec les membres via memberId</li>
+ *   <li>Validation de la validité temporelle des codes</li>
+ * </ul>
+ * 
+ * <p><strong>Contraintes de sécurité :</strong></p>
+ * <ul>
+ *   <li>Codes à usage unique (supprimés après utilisation)</li>
+ *   <li>Expiration courte (5-24h selon le contexte)</li>
+ *   <li>Format fixe à 6 chiffres pour simplicité utilisateur</li>
+ * </ul>
+ * 
+ * <p><strong>Cycle de vie :</strong></p>
+ * <ol>
+ *   <li>Création lors de l'inscription ou du renvoi</li>
+ *   <li>Envoi par email au membre</li>
+ *   <li>Validation par le membre</li>
+ *   <li>Suppression automatique après utilisation ou expiration</li>
+ * </ol>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, gestion transactionnelle JPA,
+ * validation temporelle précise, nettoyage automatique.</p>
+ *
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see Member
+ */
 @Entity
 @Table(name = "member_confirmations")
 @Data
@@ -19,29 +59,88 @@ import java.util.UUID;
 @AllArgsConstructor
 public class MemberConfirmation {
 
+    /**
+     * Identifiant unique de la confirmation, généré automatiquement via UUID.
+     * <p>
+     * Assure l'unicité de chaque code de confirmation dans la base de données.
+     * </p>
+     */
     @Id
     @GeneratedValue(generator = "uuid2")
     @UuidGenerator
     @Column(name = "id", columnDefinition = "BINARY(16)", updatable = false, nullable = false)
     private UUID id;
 
+    /**
+     * Identifiant du membre associé à ce code de confirmation.
+     * <p>
+     * Référence vers l'entité {@link Member} pour laquelle ce code
+     * de confirmation a été généré. Permet la liaison entre le code
+     * et le membre sans relation JPA directe pour optimiser les performances.
+     * </p>
+     */
     @Column(name = "member_id", columnDefinition = "BINARY(16)", nullable = false)
     private UUID memberId;
 
+    /**
+     * Code de confirmation à 6 chiffres.
+     * <p>
+     * Code numérique généré aléatoirement que le membre doit saisir
+     * pour confirmer son adresse email. Format fixe de 6 chiffres
+     * avec zéros de tête si nécessaire (ex: "012345").
+     * </p>
+     */
     @Column(nullable = false, length = 6)
     private String code;
 
+    /**
+     * Date et heure d'expiration du code de confirmation.
+     * <p>
+     * Moment précis après lequel le code devient invalide.
+     * Généralement fixé à 24h pour l'inscription initiale
+     * et 5 minutes pour les renvois de code.
+     * </p>
+     */
     @Column(nullable = false)
     private LocalDateTime expiresAt;
 
+    /**
+     * Date et heure de création du code de confirmation.
+     * <p>
+     * Généré automatiquement par Hibernate lors de la persistance.
+     * Permet de tracer la génération des codes pour audit et débogage.
+     * </p>
+     */
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    /**
+     * Vérifie si le code de confirmation a expiré.
+     * <p>
+     * Compare l'heure actuelle avec la date d'expiration pour déterminer
+     * si le code est encore valide temporellement.
+     * </p>
+     * 
+     * @return true si le code a expiré, false sinon
+     * 
+     * @implNote Utilise LocalDateTime.now() pour la comparaison en temps réel.
+     */
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(expiresAt);
     }
 
+    /**
+     * Vérifie si le code de confirmation est encore valide.
+     * <p>
+     * Méthode de convenance qui inverse le résultat de {@link #isExpired()}
+     * pour une lecture plus naturelle du code.
+     * </p>
+     * 
+     * @return true si le code est encore valide, false s'il a expiré
+     * 
+     * @see #isExpired()
+     */
     public boolean isValid() {
         return !isExpired();
     }

--- a/src/main/java/com/ecclesiaflow/io/entities/Role.java
+++ b/src/main/java/com/ecclesiaflow/io/entities/Role.java
@@ -1,6 +1,57 @@
 package com.ecclesiaflow.io.entities;
 
+/**
+ * Énumération des rôles disponibles pour les membres EcclesiaFlow.
+ * <p>
+ * Cette énumération définit les différents niveaux d'autorisation dans l'application.
+ * Utilisée par l'entité {@link Member} pour déterminer les permissions et l'accès
+ * aux fonctionnalités selon le rôle attribué.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Énumération - Modèle de données des autorisations</p>
+ * 
+ * <p><strong>Hiérarchie des rôles :</strong></p>
+ * <ul>
+ *   <li><strong>MEMBER</strong> - Membre standard avec accès aux fonctionnalités de base</li>
+ *   <li><strong>ADMIN</strong> - Administrateur avec accès complet à la gestion</li>
+ * </ul>
+ * 
+ * <p><strong>Utilisation :</strong></p>
+ * <ul>
+ *   <li>Attribution automatique du rôle MEMBER lors de l'inscription</li>
+ *   <li>Élévation manuelle au rôle ADMIN par un administrateur existant</li>
+ *   <li>Contrôle d'accès aux endpoints et fonctionnalités</li>
+ * </ul>
+ * 
+ * <p><strong>Intégration :</strong> Cette énumération est utilisée à la fois dans le
+ * module membres (pour le profil) et potentiellement dans le module d'authentification
+ * (pour les autorisations).</p>
+ * 
+ * <p><strong>Évolutivité :</strong> Peut être étendue avec de nouveaux rôles selon
+ * les besoins futurs (PASTOR, MODERATOR, etc.).</p>
+ *
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see Member
+ */
 public enum Role {
+    /**
+     * Membre standard de l'église.
+     * <p>
+     * Rôle par défaut attribué lors de l'inscription. Permet l'accès aux
+     * fonctionnalités de base de l'application : consultation du profil,
+     * mise à jour des informations personnelles, participation aux activités.
+     * </p>
+     */
     MEMBER,
+    
+    /**
+     * Administrateur de l'application.
+     * <p>
+     * Rôle avec privilèges élevés permettant la gestion complète de l'application :
+     * gestion des membres, accès aux statistiques, configuration du système,
+     * modération du contenu.
+     * </p>
+     */
     ADMIN
 }

--- a/src/main/java/com/ecclesiaflow/io/repository/MemberConfirmationRepository.java
+++ b/src/main/java/com/ecclesiaflow/io/repository/MemberConfirmationRepository.java
@@ -11,21 +11,144 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Repository Spring Data JPA pour la gestion des entités MemberConfirmation.
+ * <p>
+ * Cette interface définit les opérations de persistance pour les codes de confirmation
+ * des membres EcclesiaFlow. Gère le cycle de vie complet des codes : création,
+ * validation, expiration et nettoyage automatique.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Couche d'accès aux données - Gestion des confirmations</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Persistance et recherche des codes de confirmation</li>
+ *   <li>Validation des codes avec vérification d'expiration</li>
+ *   <li>Nettoyage automatique des codes expirés</li>
+ *   <li>Statistiques sur les confirmations en attente</li>
+ * </ul>
+ * 
+ * <p><strong>Dépendances critiques :</strong></p>
+ * <ul>
+ *   <li>Spring Data JPA - Génération automatique des implémentations</li>
+ *   <li>Base de données relationnelle - Stockage persistant avec contraintes temporelles</li>
+ * </ul>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Validation des codes saisis par les membres</li>
+ *   <li>Recherche de codes actifs pour un membre</li>
+ *   <li>Nettoyage périodique des codes expirés</li>
+ *   <li>Statistiques administratives sur les confirmations</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, transactionnel, gestion automatique de l'expiration.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ */
 @Repository
 public interface MemberConfirmationRepository extends JpaRepository<MemberConfirmation, UUID> {
 
+    /**
+     * Recherche le code de confirmation actif pour un membre donné.
+     * <p>
+     * Cette méthode retourne le code de confirmation le plus récent
+     * associé à un membre, qu'il soit expiré ou non. Utilisée pour
+     * vérifier l'existence d'un processus de confirmation en cours.
+     * </p>
+     * 
+     * @param memberId l'identifiant du membre, non null
+     * @return un {@link Optional} contenant le code de confirmation si trouvé, vide sinon
+     * @throws IllegalArgumentException si memberId est null
+     * 
+     * @implNote Génère automatiquement : SELECT * FROM member_confirmations WHERE member_id = ?
+     */
     Optional<MemberConfirmation> findByMemberId(UUID memberId);
 
+    /**
+     * Recherche un code de confirmation spécifique pour un membre donné.
+     * <p>
+     * Cette méthode valide qu'un code appartient bien au membre spécifié.
+     * Utilisée lors de la validation des tentatives de confirmation pour
+     * éviter les attaques par force brute inter-comptes.
+     * </p>
+     * 
+     * @param memberId l'identifiant du membre, non null
+     * @param code le code de confirmation à 6 chiffres, non null
+     * @return un {@link Optional} contenant le code si trouvé et valide, vide sinon
+     * @throws IllegalArgumentException si un paramètre est null
+     * 
+     * @implNote Génère : SELECT * FROM member_confirmations WHERE member_id = ? AND code = ?
+     */
     Optional<MemberConfirmation> findByMemberIdAndCode(UUID memberId, String code);
 
+    /**
+     * Recherche un code de confirmation par sa valeur uniquement.
+     * <p>
+     * Cette méthode permet de retrouver un code sans connaître le membre
+     * associé. Utilisée pour des opérations de débogage ou de maintenance.
+     * <strong>Attention :</strong> Ne pas utiliser pour la validation en production.
+     * </p>
+     * 
+     * @param code le code de confirmation à rechercher, non null
+     * @return un {@link Optional} contenant le code si trouvé, vide sinon
+     * @throws IllegalArgumentException si code est null
+     * 
+     * @implNote Génère : SELECT * FROM member_confirmations WHERE code = ?
+     * @deprecated Utiliser findByMemberIdAndCode() pour la validation sécurisée
+     */
     Optional<MemberConfirmation> findByCode(String code);
 
+    /**
+     * Supprime tous les codes de confirmation expirés.
+     * <p>
+     * Cette méthode de maintenance supprime définitivement tous les codes
+     * dont la date d'expiration est antérieure à l'instant donné.
+     * Exécutée périodiquement par un job de nettoyage.
+     * </p>
+     * 
+     * @param now l'instant de référence pour déterminer l'expiration, non null
+     * @return le nombre de codes supprimés (≥ 0)
+     * @throws IllegalArgumentException si now est null
+     * 
+     * @implNote Opération de modification : DELETE FROM member_confirmations WHERE expires_at < ?
+     */
     @Modifying
     @Query("DELETE FROM MemberConfirmation mc WHERE mc.expiresAt < :now")
     int deleteExpiredConfirmations(@Param("now") LocalDateTime now);
 
+    /**
+     * Compte le nombre de codes de confirmation encore valides.
+     * <p>
+     * Cette méthode de comptage retourne le nombre de codes de confirmation
+     * non expirés dans le système. Utilisée pour les statistiques
+     * administratives et le monitoring.
+     * </p>
+     * 
+     * @param now l'instant de référence pour déterminer la validité, non null
+     * @return le nombre de confirmations en attente (≥ 0)
+     * @throws IllegalArgumentException si now est null
+     * 
+     * @implNote Requête COUNT : SELECT COUNT(mc) FROM MemberConfirmation mc WHERE mc.expiresAt > :now
+     */
     @Query("SELECT COUNT(mc) FROM MemberConfirmation mc WHERE mc.expiresAt > :now")
     long countPendingConfirmations(@Param("now") LocalDateTime now);
 
+    /**
+     * Vérifie l'existence d'un code de confirmation pour un membre.
+     * <p>
+     * Cette méthode optimisée vérifie uniquement l'existence sans charger
+     * l'entité complète. Utilisée pour déterminer si un membre a déjà
+     * un processus de confirmation en cours.
+     * </p>
+     * 
+     * @param memberId l'identifiant du membre, non null
+     * @return true si un code existe pour ce membre, false sinon
+     * @throws IllegalArgumentException si memberId est null
+     * 
+     * @implNote Génère une requête COUNT optimisée : SELECT COUNT(*) FROM member_confirmations WHERE member_id = ?
+     */
     boolean existsByMemberId(UUID memberId);
 }

--- a/src/main/java/com/ecclesiaflow/io/repository/MemberRepository.java
+++ b/src/main/java/com/ecclesiaflow/io/repository/MemberRepository.java
@@ -71,14 +71,65 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
     Member findByRole(Role role);
 
 
+    /**
+     * Vérifie l'existence d'un membre par son adresse email.
+     * <p>
+     * Cette méthode optimisée vérifie uniquement l'existence sans charger
+     * l'entité complète. Plus performante que findByEmail() pour les vérifications
+     * d'unicité lors de l'inscription.
+     * </p>
+     * 
+     * @param email l'adresse email à vérifier, non null
+     * @return true si un membre avec cet email existe, false sinon
+     * @throws IllegalArgumentException si email est null
+     * 
+     * @implNote Génère une requête COUNT optimisée : SELECT COUNT(*) FROM members WHERE email = ?
+     */
     boolean existsByEmail(String email);
 
+    /**
+     * Recherche tous les membres selon leur statut de confirmation.
+     * <p>
+     * Cette méthode permet de filtrer les membres confirmés ou en attente
+     * de confirmation. Utilisée pour les rapports administratifs et
+     * les opérations de maintenance.
+     * </p>
+     * 
+     * @param confirmed true pour les membres confirmés, false pour ceux en attente
+     * @return la liste des membres correspondant au statut, peut être vide
+     * 
+     * @implNote Requête JPQL avec paramètre : SELECT m FROM Member m WHERE m.confirmed = :confirmed
+     */
     @Query("SELECT m FROM Member m WHERE m.confirmed = :confirmed")
     List<Member> findByConfirmedStatus(@Param("confirmed") boolean confirmed);
 
+    /**
+     * Compte le nombre de membres confirmés dans le système.
+     * <p>
+     * Cette méthode de comptage optimisée retourne le nombre total
+     * de membres ayant confirmé leur compte. Utilisée pour les
+     * statistiques et tableaux de bord administratifs.
+     * </p>
+     * 
+     * @return le nombre de membres confirmés (≥ 0)
+     * 
+     * @implNote Requête COUNT optimisée : SELECT COUNT(m) FROM Member m WHERE m.confirmed = true
+     */
     @Query("SELECT COUNT(m) FROM Member m WHERE m.confirmed = true")
     long countConfirmedMembers();
 
+    /**
+     * Compte le nombre de membres en attente de confirmation.
+     * <p>
+     * Cette méthode de comptage optimisée retourne le nombre total
+     * de membres n'ayant pas encore confirmé leur compte. Utilisée
+     * pour le suivi des inscriptions en cours et les relances.
+     * </p>
+     * 
+     * @return le nombre de membres en attente de confirmation (≥ 0)
+     * 
+     * @implNote Requête COUNT optimisée : SELECT COUNT(m) FROM Member m WHERE m.confirmed = false
+     */
     @Query("SELECT COUNT(m) FROM Member m WHERE m.confirmed = false")
     long countPendingConfirmations();
 }

--- a/src/main/java/com/ecclesiaflow/web/config/OpenApiConfig.java
+++ b/src/main/java/com/ecclesiaflow/web/config/OpenApiConfig.java
@@ -13,11 +13,57 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Configuration OpenAPI pour documenter notre API
+ * Configuration OpenAPI/Swagger pour la documentation automatique de l'API EcclesiaFlow Members.
+ * <p>
+ * Cette classe configure la génération automatique de la documentation OpenAPI 3.0
+ * et personnalise l'affichage Swagger UI. Elle définit les informations générales
+ * de l'API et ajoute automatiquement les réponses d'erreur standardisées à tous les endpoints.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Configuration - Documentation API automatique</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Configuration des métadonnées de l'API (titre, version, description)</li>
+ *   <li>Ajout automatique des réponses d'erreur standardisées (400, 401, 403, 404, 500)</li>
+ *   <li>Personnalisation de l'interface Swagger UI</li>
+ *   <li>Intégration avec le système de gestion d'erreurs {@link com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler}</li>
+ * </ul>
+ * 
+ * <p><strong>Fonctionnalités fournies :</strong></p>
+ * <ul>
+ *   <li>Documentation interactive via Swagger UI (/swagger-ui.html)</li>
+ *   <li>Spécification OpenAPI JSON/YAML (/v3/api-docs)</li>
+ *   <li>Réponses d'erreur cohérentes sur tous les endpoints</li>
+ *   <li>Schémas d'erreur réutilisables (ApiErrorResponse, ValidationError)</li>
+ * </ul>
+ * 
+ * <p><strong>Accès à la documentation :</strong></p>
+ * <ul>
+ *   <li>Interface Swagger UI : http://localhost:8080/swagger-ui.html</li>
+ *   <li>Spécification JSON : http://localhost:8080/v3/api-docs</li>
+ *   <li>Spécification YAML : http://localhost:8080/v3/api-docs.yaml</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Documentation toujours à jour, format standardisé, erreurs cohérentes.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.web.exception.model.ApiErrorResponse
+ * @see com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler
  */
 @Configuration
 public class OpenApiConfig {
 
+    /**
+     * Configure les métadonnées principales de l'API OpenAPI.
+     * <p>
+     * Cette méthode définit les informations générales qui apparaissent dans
+     * la documentation Swagger UI : titre, version, description de l'API.
+     * </p>
+     * 
+     * @return une instance {@link OpenAPI} configurée avec les métadonnées du module
+     */
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
@@ -27,6 +73,16 @@ public class OpenApiConfig {
                 .description("API pour la gestion des membres d'EcclesiaFlow"));
     }
 
+    /**
+     * Personnalise la spécification OpenAPI en ajoutant les réponses d'erreur globales.
+     * <p>
+     * Cette méthode ajoute automatiquement les réponses d'erreur standardisées
+     * (400, 401, 403, 404, 500) à tous les endpoints de l'API. Cela garantit
+     * une documentation cohérente et complète des cas d'erreur possibles.
+     * </p>
+     * 
+     * @return un {@link OpenApiCustomizer} qui enrichit la spécification
+     */
     @Bean
     public OpenApiCustomizer customerGlobalHeaderOpenApiCustomizer() {
         return openApi -> {
@@ -68,6 +124,17 @@ public class OpenApiConfig {
         };
     }
     
+    /**
+     * Crée une réponse API standardisée avec référence au schéma d'erreur.
+     * <p>
+     * Cette méthode utilitaire génère des objets {@link ApiResponse} avec
+     * une description et une référence vers le schéma d'erreur approprié.
+     * </p>
+     * 
+     * @param description la description de la réponse d'erreur
+     * @param schemaRef la référence vers le schéma OpenAPI (ex: "#/components/schemas/ApiErrorResponse")
+     * @return une {@link ApiResponse} configurée avec contenu JSON
+     */
     private ApiResponse createApiResponse(String description, String schemaRef) {
         return new ApiResponse()
             .description(description)

--- a/src/main/java/com/ecclesiaflow/web/config/WebClientConfig.java
+++ b/src/main/java/com/ecclesiaflow/web/config/WebClientConfig.java
@@ -6,10 +6,62 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
 
+/**
+ * Configuration des clients HTTP réactifs pour les appels inter-modules.
+ * <p>
+ * Cette classe configure les beans {@link WebClient} nécessaires pour communiquer
+ * avec les modules externes d'EcclesiaFlow, notamment le module d'authentification.
+ * Elle utilise des propriétés de configuration pour définir les URLs de base
+ * et peut être désactivée conditionnellement.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Configuration - Clients HTTP inter-modules</p>
+ * 
+ * <p><strong>Modules intégrés :</strong></p>
+ * <ul>
+ *   <li>Module d'authentification : gestion des mots de passe et tokens</li>
+ *   <li>Autres modules EcclesiaFlow (extensible)</li>
+ * </ul>
+ * 
+ * <p><strong>Configuration conditionnelle :</strong></p>
+ * <ul>
+ *   <li>Activée par défaut (matchIfMissing = true)</li>
+ *   <li>Peut être désactivée via ecclesiaflow.auth.module.enabled = false</li>
+ *   <li>Permet des déploiements flexibles selon l'architecture</li>
+ * </ul>
+ * 
+ * <p><strong>Propriétés requises :</strong></p>
+ * <ul>
+ *   <li>ecclesiaflow.auth.module.base-url : URL de base du module d'authentification</li>
+ * </ul>
+ * 
+ * <p><strong>Avantages WebClient :</strong></p>
+ * <ul>
+ *   <li>Client HTTP réactif non-bloquant</li>
+ *   <li>Support natif de Spring Boot</li>
+ *   <li>Configuration centralisée et réutilisable</li>
+ *   <li>Gestion automatique des timeouts et retry</li>
+ * </ul>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.business.services.impl.MemberPasswordService
+ */
 @ConditionalOnProperty(name = "ecclesiaflow.auth.module.enabled", havingValue = "true", matchIfMissing = true)
 @Configuration
 public class WebClientConfig {
 
+    /**
+     * Configure le client HTTP pour communiquer avec le module d'authentification.
+     * <p>
+     * Ce bean WebClient est configuré avec l'URL de base du module d'authentification
+     * et peut être injecté dans les services qui ont besoin de communiquer avec
+     * ce module (ex: définition de mots de passe, validation de tokens).
+     * </p>
+     * 
+     * @param baseUrl l'URL de base du module d'authentification (depuis les propriétés)
+     * @return client WebClient configuré pour le module d'authentification
+     */
     @Bean
     public WebClient authWebClient(@Value("${ecclesiaflow.auth.module.base-url}") String baseUrl) {
         return WebClient.builder()

--- a/src/main/java/com/ecclesiaflow/web/controller/MemberPasswordController.java
+++ b/src/main/java/com/ecclesiaflow/web/controller/MemberPasswordController.java
@@ -2,6 +2,12 @@ package com.ecclesiaflow.web.controller;
 
 import com.ecclesiaflow.business.services.impl.MemberPasswordService;
 import com.ecclesiaflow.web.dto.SetPasswordRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +16,49 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+/**
+ * Contrôleur REST pour la gestion des mots de passe des membres EcclesiaFlow.
+ * <p>
+ * Ce contrôleur gère spécifiquement la définition initiale des mots de passe
+ * après confirmation d'inscription. Il fait partie du flux d'inscription complet
+ * et délègue les opérations de mot de passe au module d'authentification externe.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Contrôleur web - Gestion des mots de passe</p>
+ * 
+ * <p><strong>Flux d'utilisation :</strong></p>
+ * <ol>
+ *   <li>Membre confirme son inscription → reçoit token temporaire (15 min)</li>
+ *   <li>Membre utilise token pour définir son mot de passe initial</li>
+ *   <li>Validation de la correspondance email/memberId</li>
+ *   <li>Délégation au module d'authentification pour stockage sécurisé</li>
+ * </ol>
+ * 
+ * <p><strong>Sécurité :</strong></p>
+ * <ul>
+ *   <li>Validation du token temporaire (Bearer token)</li>
+ *   <li>Vérification de la correspondance email/memberId</li>
+ *   <li>Délégation au module d'authentification pour le hachage</li>
+ *   <li>Token à durée limitée (15 minutes)</li>
+ * </ul>
+ * 
+ * <p><strong>Intégration :</strong></p>
+ * <ul>
+ *   <li>Module membres : validation de l'identité</li>
+ *   <li>Module d'authentification : stockage sécurisé du mot de passe</li>
+ *   <li>Système de tokens temporaires</li>
+ * </ul>
+ * 
+ * <p><strong>Endpoints :</strong></p>
+ * <ul>
+ *   <li>POST /ecclesiaflow/members/{memberId}/password - Définir mot de passe initial</li>
+ * </ul>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see MemberPasswordService
+ * @see SetPasswordRequest
+ */
 @RestController
 @RequestMapping("/ecclesiaflow/members")
 @RequiredArgsConstructor
@@ -18,6 +67,90 @@ public class MemberPasswordController {
 
     private final MemberPasswordService memberPasswordService;
 
+    @Operation(
+        summary = "Définir le mot de passe initial d'un membre",
+        description = """
+            Permet à un membre confirmé de définir son mot de passe initial après confirmation d'inscription.
+            Nécessite un token temporaire valide (durée: 15 minutes) obtenu lors de la confirmation.
+            Valide la correspondance entre l'email et l'ID du membre avant délégation au module d'authentification.
+            """,
+        tags = {"Member Password"}
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Mot de passe défini avec succès",
+            content = @Content
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Requête invalide - données manquantes, format incorrect ou token expiré",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = com.ecclesiaflow.web.dto.ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "Erreur de validation",
+                    value = """
+                        {
+                          "timestamp": "2023-12-01T10:30:00",
+                          "status": 400,
+                          "error": "Bad Request",
+                          "message": "Le mot de passe doit contenir au moins 8 caractères",
+                          "path": "/ecclesiaflow/members/123e4567-e89b-12d3-a456-426614174000/password"
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "Token temporaire invalide ou expiré",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = com.ecclesiaflow.web.dto.ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "Token expiré",
+                    value = """
+                        {
+                          "timestamp": "2023-12-01T10:30:00",
+                          "status": 401,
+                          "error": "Unauthorized",
+                          "message": "Token temporaire expiré",
+                          "path": "/ecclesiaflow/members/123e4567-e89b-12d3-a456-426614174000/password"
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Membre non trouvé",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = com.ecclesiaflow.web.dto.ErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "Membre inexistant",
+                    value = """
+                        {
+                          "timestamp": "2023-12-01T10:30:00",
+                          "status": 404,
+                          "error": "Not Found",
+                          "message": "Aucun membre trouvé avec cet ID",
+                          "path": "/ecclesiaflow/members/123e4567-e89b-12d3-a456-426614174000/password"
+                        }
+                        """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Erreur interne du serveur",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = com.ecclesiaflow.web.dto.ErrorResponse.class)
+            )
+        )
+    })
     @PostMapping(value = "/{memberId}/password", produces = "application/vnd.ecclesiaflow.members.v1+json")
     public ResponseEntity<Void> setPassword(
             @PathVariable UUID memberId,

--- a/src/main/java/com/ecclesiaflow/web/controller/MembersConfirmationController.java
+++ b/src/main/java/com/ecclesiaflow/web/controller/MembersConfirmationController.java
@@ -4,7 +4,6 @@ import com.ecclesiaflow.business.mappers.ConfirmationResponseMapper;
 import com.ecclesiaflow.business.mappers.ConfirmationRequestMapper;
 import com.ecclesiaflow.business.domain.MembershipConfirmationResult;
 import com.ecclesiaflow.business.domain.MembershipConfirmation;
-import com.ecclesiaflow.io.repository.MemberConfirmationRepository;
 import com.ecclesiaflow.web.dto.ConfirmationRequest;
 import com.ecclesiaflow.web.dto.ConfirmationResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,10 +20,49 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 /**
- * Contrôleur pour la confirmation des comptes membres
- *
- * Gère la confirmation des comptes via code envoyé par email
- * et génère un token temporaire pour définir le mot de passe
+ * Contrôleur REST pour la gestion du processus de confirmation des membres EcclesiaFlow.
+ * <p>
+ * Ce contrôleur gère le processus complet de confirmation des comptes membres :
+ * validation des codes de confirmation envoyés par email, mise à jour du statut
+ * de confirmation, et génération de tokens temporaires pour la définition des mots de passe.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Couche de présentation - API REST Confirmation</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Validation des codes de confirmation saisis par les membres</li>
+ *   <li>Orchestration du processus de confirmation avec les services métier</li>
+ *   <li>Génération et retour des tokens temporaires</li>
+ *   <li>Gestion des erreurs de confirmation (code invalide, expiré, etc.)</li>
+ *   <li>Endpoints de débogage pour les tests (temporaires)</li>
+ * </ul>
+ * 
+ * <p><strong>Dépendances critiques :</strong></p>
+ * <ul>
+ *   <li>{@link MemberConfirmationService} - Logique métier de confirmation</li>
+ *   <li>Mappers - Transformation DTOs ↔ objets métier</li>
+ *   <li>Spring Web MVC - Framework REST</li>
+ * </ul>
+ * 
+ * <p><strong>Endpoints exposés :</strong></p>
+ * <ul>
+ *   <li>POST /ecclesiaflow/members/{memberId}/confirmation - Confirmer un compte</li>
+ *   <li>GET /ecclesiaflow/members/{memberId}/confirmation/debug/code - Debug (temporaire)</li>
+ * </ul>
+ * 
+ * <p><strong>Flux typique :</strong></p>
+ * <ol>
+ *   <li>Membre reçoit un email avec code de confirmation</li>
+ *   <li>Membre saisit le code via l'interface</li>
+ *   <li>Validation du code et mise à jour du statut</li>
+ *   <li>Génération d'un token temporaire pour définir le mot de passe</li>
+ * </ol>
+ * 
+ * <p><strong>Garanties :</strong> Validation automatique, sécurité des codes, gestion d'erreurs.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
  */
 @RestController
 @RequestMapping("ecclesiaflow/members/{memberId}")

--- a/src/main/java/com/ecclesiaflow/web/controller/MembersController.java
+++ b/src/main/java/com/ecclesiaflow/web/controller/MembersController.java
@@ -27,13 +27,50 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * CONTRÔLEUR TEMPORAIRE - À MIGRER VERS LE MODULE DE GESTION DES MEMBRES
+ * Contrôleur REST pour la gestion des membres EcclesiaFlow.
+ * <p>
+ * Ce contrôleur expose les endpoints HTTP pour les opérations CRUD sur les membres :
+ * inscription, consultation, mise à jour et suppression. Respecte les principes
+ * REST et utilise une architecture en couches avec mappers pour la transformation
+ * des données entre DTOs et objets métier.
+ * </p>
  * 
- * Ce contrôleur sera déplacé vers ecclesiaflow-member-management-module
- * dans la future architecture multi-tenant où :
- * - Les pasteurs (admins tenant) créent les membres
- * - Les demandes d'inscription sont soumises pour approbation
- * - La gestion des membres est séparée de l'authentification
+ * <p><strong>⚠️ STATUT TEMPORAIRE :</strong> Ce contrôleur sera migré vers le module
+ * ecclesiaflow-member-management-module dans la future architecture multi-tenant.</p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Couche de présentation - API REST</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Exposition des endpoints HTTP pour la gestion des membres</li>
+ *   <li>Validation des données d'entrée via annotations Bean Validation</li>
+ *   <li>Transformation des DTOs en objets métier via mappers</li>
+ *   <li>Gestion des codes de statut HTTP appropriés</li>
+ *   <li>Documentation OpenAPI/Swagger intégrée</li>
+ * </ul>
+ * 
+ * <p><strong>Dépendances critiques :</strong></p>
+ * <ul>
+ *   <li>{@link MemberService} - Logique métier des membres</li>
+ *   <li>Mappers - Transformation DTOs ↔ objets métier</li>
+ *   <li>Spring Web MVC - Framework REST</li>
+ * </ul>
+ * 
+ * <p><strong>Endpoints exposés :</strong></p>
+ * <ul>
+ *   <li>GET /ecclesiaflow/hello - Test d'authentification</li>
+ *   <li>POST /ecclesiaflow/members - Inscription d'un nouveau membre</li>
+ *   <li>GET /ecclesiaflow/members/{id} - Consultation d'un membre</li>
+ *   <li>PATCH /ecclesiaflow/members/{id} - Mise à jour d'un membre</li>
+ *   <li>DELETE /ecclesiaflow/members/{id} - Suppression d'un membre</li>
+ *   <li>GET /ecclesiaflow/members - Liste de tous les membres</li>
+ *   <li>GET /ecclesiaflow/members/{email}/confirmation-status - Statut de confirmation</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Validation automatique, gestion d'erreurs, documentation OpenAPI.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
  */
 @RestController
 @RequestMapping("/ecclesiaflow")
@@ -43,6 +80,18 @@ public class MembersController {
     private final MemberService memberService;
     private final MemberUpdateMapper memberUpdateMapper;
 
+    /**
+     * Endpoint de test d'authentification pour les membres.
+     * <p>
+     * Cette méthode simple permet de vérifier que l'authentification JWT
+     * fonctionne correctement pour les membres connectés. Retourne un message
+     * de bienvenue basique.
+     * </p>
+     * 
+     * @return {@link ResponseEntity} contenant le message "Hi Member" avec statut HTTP 200
+     * 
+     * @implNote Endpoint sécurisé nécessitant un token JWT valide.
+     */
     @GetMapping(value = "/hello", produces = "application/vnd.ecclesiaflow.members.v1+json")
     @Operation(
         summary = "Message de bienvenue pour les membres",
@@ -83,6 +132,23 @@ public class MembersController {
             content = @Content
         )
     })
+    /**
+     * Enregistre un nouveau membre dans le système.
+     * <p>
+     * Cette méthode permet l'auto-inscription d'un nouveau membre.
+     * Elle valide les données d'entrée, transforme le DTO en objet métier,
+     * appelle le service pour l'enregistrement, puis retourne la réponse formatée.
+     * </p>
+     * 
+     * <p><strong>⚠️ TEMPORAIRE :</strong> Sera remplacé par un système d'approbation admin.</p>
+     * 
+     * @param signUpRequest les données d'inscription du membre, validées automatiquement
+     * @return {@link ResponseEntity} avec {@link MemberResponse} et statut HTTP 201
+     * @throws org.springframework.web.bind.MethodArgumentNotValidException si les données sont invalides
+     * @throws IllegalArgumentException si l'email existe déjà
+     * 
+     * @implNote Utilise le pattern Mapper pour la transformation DTO → Objet métier → DTO.
+     */
     public ResponseEntity<MemberResponse> registerMember(@Valid @RequestBody SignUpRequest signUpRequest) {
         MembershipRegistration registration = MemberMapper.fromSignUpRequest(signUpRequest);
         Member member = memberService.registerMember(registration);

--- a/src/main/java/com/ecclesiaflow/web/dto/ConfirmationRequest.java
+++ b/src/main/java/com/ecclesiaflow/web/dto/ConfirmationRequest.java
@@ -5,8 +5,53 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
+/**
+ * DTO représentant une requête de confirmation de compte membre via l'API web.
+ * <p>
+ * Cette classe encapsule le code de confirmation à 6 chiffres saisi par le membre
+ * pour valider son adresse email. Utilise les annotations de validation Jakarta
+ * pour assurer l'intégrité du format du code avant traitement.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> DTO web - Requête de confirmation</p>
+ * 
+ * <p><strong>Validations appliquées :</strong></p>
+ * <ul>
+ *   <li>Code obligatoire et non vide</li>
+ *   <li>Format exact : 6 chiffres numériques (regex: \\d{6})</li>
+ *   <li>Pas d'espaces ou caractères spéciaux autorisés</li>
+ * </ul>
+ * 
+ * <p><strong>Flux de traitement :</strong></p>
+ * <ol>
+ *   <li>Réception du code via API REST</li>
+ *   <li>Validation automatique par Spring Boot</li>
+ *   <li>Conversion en objet métier {@link com.ecclesiaflow.business.domain.MembershipConfirmation}</li>
+ *   <li>Traitement par {@link com.ecclesiaflow.business.services.MemberConfirmationService}</li>
+ * </ol>
+ * 
+ * <p><strong>Exemples de codes valides :</strong> "123456", "000001", "999999"</p>
+ * <p><strong>Exemples de codes invalides :</strong> "12345", "1234567", "abc123", "12 34 56"</p>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, validation automatique, format strict.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.business.domain.MembershipConfirmation
+ * @see com.ecclesiaflow.web.controller.MembersConfirmationController
+ */
 @Data
 public class ConfirmationRequest {
+    /**
+     * Code de confirmation à 6 chiffres saisi par le membre.
+     * <p>
+     * Code numérique que le membre a reçu par email et qu'il doit saisir
+     * pour confirmer son adresse email. Doit être exactement 6 chiffres
+     * numériques sans espaces ni caractères spéciaux.
+     * </p>
+     * 
+     * @implNote Validation par regex \\d{6} pour garantir le format exact.
+     */
     @NotBlank(message = "Le code de confirmation est obligatoire")
     @Pattern(regexp = "\\d{6}", message = "Le code doit contenir exactement 6 chiffres")
     private String code;

--- a/src/main/java/com/ecclesiaflow/web/dto/ConfirmationResponse.java
+++ b/src/main/java/com/ecclesiaflow/web/dto/ConfirmationResponse.java
@@ -3,10 +3,73 @@ package com.ecclesiaflow.web.dto;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * DTO représentant la réponse après confirmation réussie d'un compte membre.
+ * <p>
+ * Cette classe encapsule les données de réponse envoyées au client après
+ * une confirmation de compte réussie. Contient le message de succès et
+ * le token temporaire permettant de définir le mot de passe initial.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> DTO web - Réponse de confirmation</p>
+ * 
+ * <p><strong>Contenu de la réponse :</strong></p>
+ * <ul>
+ *   <li>Message de confirmation pour l'utilisateur</li>
+ *   <li>Token temporaire pour accéder à la définition du mot de passe</li>
+ *   <li>Durée de validité du token en secondes</li>
+ * </ul>
+ * 
+ * <p><strong>Flux de génération :</strong></p>
+ * <ol>
+ *   <li>Service métier génère {@link com.ecclesiaflow.business.domain.MembershipConfirmationResult}</li>
+ *   <li>Mapper convertit en ConfirmationResponse</li>
+ *   <li>Contrôleur retourne la réponse au client</li>
+ * </ol>
+ * 
+ * <p><strong>Utilisation côté client :</strong></p>
+ * <ul>
+ *   <li>Affichage du message de succès à l'utilisateur</li>
+ *   <li>Redirection vers la page de définition du mot de passe</li>
+ *   <li>Gestion de l'expiration du token temporaire</li>
+ * </ul>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, construction flexible, données cohérentes.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.business.domain.MembershipConfirmationResult
+ * @see com.ecclesiaflow.web.controller.MembersConfirmationController
+ */
 @Data
 @Builder
 public class ConfirmationResponse {
+    /**
+     * Message de confirmation pour l'utilisateur.
+     * <p>
+     * Message informatif confirmant le succès de la validation du code
+     * et guidant l'utilisateur vers les prochaines étapes (définition du mot de passe).
+     * </p>
+     */
     private String message;
+    
+    /**
+     * Token temporaire pour définir le mot de passe.
+     * <p>
+     * Token sécurisé généré par le module d'authentification permettant
+     * au membre nouvellement confirmé de définir son mot de passe initial.
+     * Doit être utilisé dans les requêtes vers l'endpoint de définition de mot de passe.
+     * </p>
+     */
     private String temporaryToken;
+    
+    /**
+     * Durée de validité du token temporaire en secondes.
+     * <p>
+     * Nombre de secondes pendant lesquelles le token temporaire reste valide.
+     * Permet au client de calculer l'heure d'expiration et d'afficher
+     * un compte à rebours à l'utilisateur.
+     * </p>
+     */
     private long expiresIn;
 }

--- a/src/main/java/com/ecclesiaflow/web/dto/ErrorResponse.java
+++ b/src/main/java/com/ecclesiaflow/web/dto/ErrorResponse.java
@@ -2,6 +2,46 @@ package com.ecclesiaflow.web.dto;
 
 import java.time.LocalDateTime;
 
+/**
+ * DTO représentant une réponse d'erreur standardisée pour l'API EcclesiaFlow.
+ * <p>
+ * Cette classe record encapsule les informations d'erreur retournées par l'API
+ * lors d'exceptions ou d'erreurs de validation. Fournit un format cohérent
+ * pour toutes les réponses d'erreur du module membres.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> DTO web - Réponse d'erreur standardisée</p>
+ * 
+ * <p><strong>Format de réponse :</strong></p>
+ * <ul>
+ *   <li>Horodatage précis de l'erreur</li>
+ *   <li>Code de statut HTTP</li>
+ *   <li>Type d'erreur (ex: "Bad Request", "Internal Server Error")</li>
+ *   <li>Message descriptif de l'erreur</li>
+ *   <li>Chemin de la requête qui a causé l'erreur</li>
+ * </ul>
+ * 
+ * <p><strong>Utilisation :</strong></p>
+ * <ul>
+ *   <li>Gestion centralisée des erreurs via {@link com.ecclesiaflow.web.exception.GlobalExceptionHandler}</li>
+ *   <li>Réponses d'erreur de validation</li>
+ *   <li>Erreurs métier et techniques</li>
+ *   <li>Documentation OpenAPI des réponses d'erreur</li>
+ * </ul>
+ * 
+ * <p><strong>Avantages du record :</strong> Immutabilité, equals/hashCode automatiques,
+ * sérialisation JSON native, construction concise.</p>
+ * 
+ * @param timestamp Horodatage de l'erreur
+ * @param status Code de statut HTTP (400, 404, 500, etc.)
+ * @param error Type d'erreur HTTP
+ * @param message Message descriptif de l'erreur
+ * @param path Chemin de la requête qui a causé l'erreur
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.web.exception.GlobalExceptionHandler
+ */
 public record ErrorResponse(LocalDateTime timestamp,
                             int status,
                             String error,

--- a/src/main/java/com/ecclesiaflow/web/dto/MemberResponse.java
+++ b/src/main/java/com/ecclesiaflow/web/dto/MemberResponse.java
@@ -3,23 +3,127 @@ package com.ecclesiaflow.web.dto;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * DTO représentant la réponse contenant les informations d'un membre EcclesiaFlow.
+ * <p>
+ * Cette classe encapsule les données de profil d'un membre retournées par l'API
+ * après inscription réussie ou consultation de profil. Respecte la séparation
+ * des couches en servant d'interface entre les services métier et les clients.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> DTO web - Réponse de données membre</p>
+ * 
+ * <p><strong>Contenu de la réponse :</strong></p>
+ * <ul>
+ *   <li>Informations de profil (nom, prénom, email, adresse)</li>
+ *   <li>Statut du compte (confirmé, actif, verrouillé)</li>
+ *   <li>Informations d'authentification (rôle, token si applicable)</li>
+ *   <li>Métadonnées temporelles (date de création)</li>
+ * </ul>
+ * 
+ * <p><strong>Flux de génération :</strong></p>
+ * <ol>
+ *   <li>Service métier retourne entité {@link com.ecclesiaflow.io.entities.Member}</li>
+ *   <li>Mapper convertit en MemberResponse</li>
+ *   <li>Contrôleur retourne la réponse au client</li>
+ * </ol>
+ * 
+ * <p><strong>Cas d'utilisation :</strong></p>
+ * <ul>
+ *   <li>Réponse après inscription réussie</li>
+ *   <li>Consultation de profil membre</li>
+ *   <li>Mise à jour de profil</li>
+ *   <li>Authentification et autorisation côté client</li>
+ * </ul>
+ * 
+ * <p><strong>Sécurité :</strong> Ne contient jamais le mot de passe en clair,
+ * seulement les informations publiques du profil.</p>
+ * 
+ * <p><strong>Garanties :</strong> Thread-safe, construction flexible, données cohérentes.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.io.entities.Member
+ * @see com.ecclesiaflow.web.controller.MembersController
+ */
 @Data
 @Builder
 public class MemberResponse {
+    /**
+     * Message informatif pour l'utilisateur (optionnel).
+     */
     private String message;
+    
+    /**
+     * Adresse email du membre.
+     */
     private String email;
+    
+    /**
+     * Prénom du membre.
+     */
     private String firstName;
+    
+    /**
+     * Nom de famille du membre.
+     */
     private String lastName;
+    
+    /**
+     * Adresse physique du membre (optionnelle).
+     */
     private String address;
+    
+    /**
+     * Champ mot de passe (ne devrait jamais être rempli pour des raisons de sécurité).
+     * @deprecated Ce champ ne devrait pas être utilisé dans les réponses
+     */
+    @Deprecated
     private String password;
+    
+    /**
+     * Rôle du membre dans l'application.
+     */
     private String role;
+    
+    /**
+     * Indique si le compte n'est pas verrouillé.
+     */
     private boolean accountNonLocked;
+    
+    /**
+     * Indique si le compte est activé.
+     */
     private boolean enabled;
+    
+    /**
+     * Token d'authentification (si applicable).
+     */
     private String token;
+    
+    /**
+     * Nom d'utilisateur (généralement l'email).
+     */
     private String username;
+    
+    /**
+     * Indique si le compte a été confirmé par email.
+     */
     private boolean confirmed;
+    
+    /**
+     * Date de création du compte (format ISO).
+     */
     private String createdAt;
+    
+    /**
+     * Indique si le compte n'a pas expiré.
+     */
     private boolean accountNonExpired;
+    
+    /**
+     * Indique si les informations d'identification n'ont pas expiré.
+     */
     private boolean credentialsNonExpired;
 }
 

--- a/src/main/java/com/ecclesiaflow/web/dto/SetPasswordRequest.java
+++ b/src/main/java/com/ecclesiaflow/web/dto/SetPasswordRequest.java
@@ -11,10 +11,44 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * DTO pour définir le mot de passe initial d'un membre.
- *
+ * DTO représentant une requête de définition de mot de passe initial pour un membre EcclesiaFlow.
+ * <p>
+ * Cette classe encapsule les données nécessaires pour permettre à un membre confirmé
+ * de définir son mot de passe initial via un token temporaire. Utilisée dans le
+ * processus post-confirmation d'inscription.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> DTO web - Requête de définition de mot de passe</p>
+ * 
+ * <p><strong>Flux d'utilisation :</strong></p>
+ * <ol>
+ *   <li>Membre confirme son inscription → reçoit token temporaire</li>
+ *   <li>Membre utilise token pour accéder au formulaire de mot de passe</li>
+ *   <li>Soumission de cette requête avec email, mot de passe et token</li>
+ *   <li>Validation et délégation au module d'authentification</li>
+ * </ol>
+ * 
+ * <p><strong>Validations appliquées :</strong></p>
+ * <ul>
+ *   <li>Email : format valide et obligatoire</li>
+ *   <li>Mot de passe : 8+ caractères, complexité (maj/min/chiffre/spécial)</li>
+ *   <li>Token temporaire : présence obligatoire</li>
+ * </ul>
+ * 
+ * <p><strong>Sécurité :</strong></p>
+ * <ul>
+ *   <li>Token temporaire à durée limitée (1h)</li>
+ *   <li>Validation côté serveur des critères de mot de passe</li>
+ *   <li>Transmission sécurisée vers module d'authentification</li>
+ * </ul>
+ * 
+ * <p><strong>Intégration :</strong> Utilisée par {@link com.ecclesiaflow.web.controller.MemberPasswordController}
+ * et traitée par {@link com.ecclesiaflow.business.services.impl.MemberPasswordService}.</p>
+ * 
  * @author EcclesiaFlow Team
  * @since 1.0.0
+ * @see com.ecclesiaflow.web.controller.MemberPasswordController
+ * @see com.ecclesiaflow.business.services.impl.MemberPasswordService
  */
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/ecclesiaflow/web/dto/UpdateMemberRequest.java
+++ b/src/main/java/com/ecclesiaflow/web/dto/UpdateMemberRequest.java
@@ -3,17 +3,69 @@ package com.ecclesiaflow.web.dto;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
+/**
+ * DTO représentant une requête de mise à jour des informations d'un membre EcclesiaFlow.
+ * <p>
+ * Cette classe encapsule les données modifiables d'un profil membre lors d'une
+ * opération de mise à jour. Tous les champs sont optionnels, permettant des
+ * mises à jour partielles selon les besoins de l'utilisateur.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> DTO web - Requête de mise à jour membre</p>
+ * 
+ * <p><strong>Stratégie de mise à jour :</strong></p>
+ * <ul>
+ *   <li>Mise à jour partielle : seuls les champs non-null sont modifiés</li>
+ *   <li>Validation des tailles maximales pour chaque champ</li>
+ *   <li>Conservation des valeurs existantes pour les champs omis</li>
+ * </ul>
+ * 
+ * <p><strong>Champs modifiables :</strong></p>
+ * <ul>
+ *   <li>Nom de famille (max 50 caractères)</li>
+ *   <li>Prénom (max 50 caractères)</li>
+ *   <li>Adresse physique (max 200 caractères)</li>
+ *   <li>Email (max 100 caractères)</li>
+ * </ul>
+ * 
+ * <p><strong>Flux de traitement :</strong></p>
+ * <ol>
+ *   <li>Réception de la requête par le contrôleur</li>
+ *   <li>Validation des contraintes de taille</li>
+ *   <li>Conversion vers objet métier {@link com.ecclesiaflow.business.domain.MembershipUpdate}</li>
+ *   <li>Traitement par le service métier</li>
+ * </ol>
+ * 
+ * <p><strong>Sécurité :</strong> Validation côté serveur, pas de champs sensibles exposés.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.business.domain.MembershipUpdate
+ * @see com.ecclesiaflow.web.controller.MembersController
+ */
 @Data
 public class UpdateMemberRequest {
+    /**
+     * Nouveau nom de famille du membre (optionnel).
+     */
     @Size(max = 50, message = "Le nom ne peut pas dépasser 50 caractères")
     private String lastName;
 
+    /**
+     * Nouveau prénom du membre (optionnel).
+     */
     @Size(max = 50, message = "Le prénom ne peut pas dépasser 50 caractères")
     private String firstName;
 
+    /**
+     * Nouvelle adresse physique du membre (optionnelle).
+     */
     @Size(max = 200, message = "L'adresse ne peut pas dépasser 200 caractères")
     private String address;
 
+    /**
+     * Nouvelle adresse email du membre (optionnelle).
+     */
     @Size(max = 100, message = "L'email ne peut pas dépasser 100 caractères")
     private String email;
 }

--- a/src/main/java/com/ecclesiaflow/web/exception/ConfirmationEmailException.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/ConfirmationEmailException.java
@@ -1,6 +1,54 @@
 package com.ecclesiaflow.web.exception;
 
+/**
+ * Exception spécialisée levée lors d'un échec d'envoi d'email de confirmation d'inscription.
+ * <p>
+ * Cette exception hérite de {@link EmailSendingException} et est spécifiquement utilisée
+ * pour les erreurs d'envoi des emails contenant les codes de confirmation lors du
+ * processus d'inscription des nouveaux membres.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Exception technique spécialisée - Emails de confirmation</p>
+ * 
+ * <p><strong>Contexte d'utilisation :</strong></p>
+ * <ul>
+ *   <li>Échec d'envoi du premier email de confirmation après inscription</li>
+ *   <li>Problèmes lors du renvoi de codes de confirmation</li>
+ *   <li>Erreurs spécifiques au template d'email de confirmation</li>
+ *   <li>Problèmes de génération du contenu de confirmation</li>
+ * </ul>
+ * 
+ * <p><strong>Contenu de l'email concerné :</strong></p>
+ * <ul>
+ *   <li>Code de confirmation à 6 chiffres</li>
+ *   <li>Instructions de confirmation</li>
+ *   <li>Lien vers l'interface de confirmation</li>
+ *   <li>Informations de contact et support</li>
+ * </ul>
+ * 
+ * <p><strong>Impact sur le flux utilisateur :</strong></p>
+ * <ul>
+ *   <li>L'inscription est enregistrée mais le membre ne reçoit pas son code</li>
+ *   <li>Possibilité de renvoi via l'endpoint dédié</li>
+ *   <li>Support manuel possible via les logs détaillés</li>
+ * </ul>
+ * 
+ * <p><strong>Gestion :</strong> Hérite de la gestion de {@link EmailSendingException}
+ * avec logging spécifique aux emails de confirmation.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see EmailSendingException
+ * @see com.ecclesiaflow.business.services.impl.EmailServiceImpl
+ */
 public class ConfirmationEmailException extends EmailSendingException {
+    
+    /**
+     * Construit une nouvelle exception avec le message et la cause spécifiés.
+     * 
+     * @param message le message d'erreur décrivant le problème d'envoi de confirmation
+     * @param cause la cause sous-jacente de l'exception (ex: MailException)
+     */
     public ConfirmationEmailException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/ecclesiaflow/web/exception/EmailSendingException.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/EmailSendingException.java
@@ -1,10 +1,63 @@
 package com.ecclesiaflow.web.exception;
 
+/**
+ * Exception levée lors d'un échec d'envoi d'email par le service de messagerie.
+ * <p>
+ * Cette exception est utilisée par {@link com.ecclesiaflow.business.services.impl.EmailServiceImpl}
+ * pour signaler les problèmes techniques liés à l'envoi d'emails via le serveur SMTP.
+ * Elle encapsule les erreurs de configuration, de connectivité ou de transmission.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Exception technique - Gestion des erreurs d'envoi d'email</p>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Problèmes de connexion au serveur SMTP (Gmail)</li>
+ *   <li>Erreurs d'authentification SMTP</li>
+ *   <li>Adresses email destinataires invalides</li>
+ *   <li>Quotas d'envoi dépassés</li>
+ *   <li>Problèmes de configuration du serveur de mail</li>
+ * </ul>
+ * 
+ * <p><strong>Types d'emails concernés :</strong></p>
+ * <ul>
+ *   <li>Emails de confirmation d'inscription</li>
+ *   <li>Emails de bienvenue</li>
+ *   <li>Emails de réinitialisation de mot de passe</li>
+ * </ul>
+ * 
+ * <p><strong>Stratégie de gestion :</strong></p>
+ * <ul>
+ *   <li>L'inscription du membre continue même si l'email échoue</li>
+ *   <li>Logging détaillé pour le diagnostic</li>
+ *   <li>Possibilité de renvoi manuel des emails</li>
+ * </ul>
+ * 
+ * <p><strong>Gestion :</strong> Capturée par {@link com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler}
+ * et transformée en réponse HTTP 500 avec message d'erreur technique.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.business.services.impl.EmailServiceImpl
+ * @see com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler
+ */
 public class EmailSendingException extends RuntimeException {
+    
+    /**
+     * Construit une nouvelle exception avec le message spécifié.
+     * 
+     * @param message le message d'erreur décrivant le problème d'envoi
+     */
     public EmailSendingException(String message) {
         super(message);
     }
 
+    /**
+     * Construit une nouvelle exception avec le message et la cause spécifiés.
+     * 
+     * @param message le message d'erreur décrivant le problème d'envoi
+     * @param cause la cause sous-jacente de l'exception (ex: MailException)
+     */
     public EmailSendingException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/ecclesiaflow/web/exception/ExpiredConfirmationCodeException.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/ExpiredConfirmationCodeException.java
@@ -1,14 +1,58 @@
 package com.ecclesiaflow.web.exception;
 
 /**
- * Exception lancée lorsque le code de confirmation a expiré
+ * Exception levée lorsqu'un code de confirmation a dépassé sa durée de validité.
+ * <p>
+ * Cette exception est spécifiquement utilisée lors du processus de confirmation des comptes
+ * membres lorsque le code fourni est correct mais a expiré selon les règles temporelles
+ * définies dans l'application (typiquement 24h pour les codes initiaux, 5 min pour les renvois).
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Exception métier - Gestion de l'expiration temporelle</p>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Code de confirmation initial expiré après 24h</li>
+ *   <li>Code de renvoi expiré après 5 minutes</li>
+ *   <li>Tentative de confirmation tardive par l'utilisateur</li>
+ *   <li>Validation temporelle lors du processus de confirmation</li>
+ * </ul>
+ * 
+ * <p><strong>Différence avec InvalidConfirmationCodeException :</strong></p>
+ * <ul>
+ *   <li>ExpiredConfirmationCodeException : Code valide mais expiré</li>
+ *   <li>InvalidConfirmationCodeException : Code incorrect ou inexistant</li>
+ * </ul>
+ * 
+ * <p><strong>Comportement attendu :</strong> L'utilisateur doit demander un nouveau
+ * code de confirmation via l'endpoint de renvoi.</p>
+ * 
+ * <p><strong>Gestion :</strong> Capturée par {@link com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler}
+ * et transformée en réponse HTTP 400 avec message d'erreur spécifique à l'expiration.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.web.exception.InvalidConfirmationCodeException
+ * @see com.ecclesiaflow.business.services.MemberConfirmationService
+ * @see com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler
  */
 public class ExpiredConfirmationCodeException extends RuntimeException {
     
+    /**
+     * Construit une nouvelle exception avec le message spécifié.
+     * 
+     * @param message le message d'erreur décrivant l'expiration du code
+     */
     public ExpiredConfirmationCodeException(String message) {
         super(message);
     }
     
+    /**
+     * Construit une nouvelle exception avec le message et la cause spécifiés.
+     * 
+     * @param message le message d'erreur décrivant l'expiration du code
+     * @param cause la cause sous-jacente de l'exception
+     */
     public ExpiredConfirmationCodeException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/ecclesiaflow/web/exception/InvalidConfirmationCodeException.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/InvalidConfirmationCodeException.java
@@ -1,14 +1,51 @@
 package com.ecclesiaflow.web.exception;
 
 /**
- * Exception lancée lorsque le code de confirmation est invalide
+ * Exception levée lorsqu'un code de confirmation est invalide ou expiré.
+ * <p>
+ * Cette exception est utilisée lors du processus de confirmation des comptes membres
+ * lorsque le code fourni ne correspond pas au code attendu, est expiré, ou a déjà
+ * été utilisé. Elle fait partie du système de sécurité pour prévenir les tentatives
+ * de confirmation frauduleuses.
+ * </p>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Code de confirmation incorrect saisi par l'utilisateur</li>
+ *   <li>Code expiré (dépassement de la durée de validité)</li>
+ *   <li>Code déjà utilisé pour une confirmation précédente</li>
+ *   <li>Tentatives d'attaque par force brute sur les codes</li>
+ *   <li>Code inexistant en base de données</li>
+ * </ul>
+ * 
+ * <p><strong>Sécurité :</strong> Les messages d'erreur sont volontairement génériques
+ * pour ne pas révéler d'informations sensibles aux attaquants.</p>
+ * 
+ * <p><strong>Gestion :</strong> Capturée par {@link com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler}
+ * et transformée en réponse HTTP 400 avec message d'erreur standardisé.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler
+ * @see com.ecclesiaflow.business.services.MemberConfirmationService
  */
 public class InvalidConfirmationCodeException extends RuntimeException {
     
+    /**
+     * Construit une nouvelle exception avec le message spécifié.
+     * 
+     * @param message le message d'erreur décrivant le problème de validation
+     */
     public InvalidConfirmationCodeException(String message) {
         super(message);
     }
     
+    /**
+     * Construit une nouvelle exception avec le message et la cause spécifiés.
+     * 
+     * @param message le message d'erreur décrivant le problème de validation
+     * @param cause la cause sous-jacente de l'exception
+     */
     public InvalidConfirmationCodeException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/ecclesiaflow/web/exception/InvalidRequestException.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/InvalidRequestException.java
@@ -1,14 +1,58 @@
 package com.ecclesiaflow.web.exception;
 
 /**
- * Exception levée lors d'une requête avec des paramètres invalides
+ * Exception levée lors d'une requête contenant des paramètres ou des données invalides.
+ * <p>
+ * Cette exception générique est utilisée pour signaler des erreurs de validation
+ * métier ou des incohérences dans les données de requête qui ne relèvent pas
+ * des validations automatiques de Spring (Bean Validation).
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Exception métier - Validation des requêtes</p>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Paramètres de requête incohérents ou contradictoires</li>
+ *   <li>Violations de règles métier complexes</li>
+ *   <li>Données de requête corrompues ou malformées</li>
+ *   <li>Tentatives d'opérations non autorisées selon le contexte</li>
+ *   <li>Validation cross-field échouée</li>
+ * </ul>
+ * 
+ * <p><strong>Différence avec les autres exceptions :</strong></p>
+ * <ul>
+ *   <li>InvalidRequestException : Erreurs générales de validation métier</li>
+ *   <li>MethodArgumentNotValidException : Erreurs de validation Bean Validation</li>
+ *   <li>InvalidConfirmationCodeException : Erreurs spécifiques aux codes</li>
+ * </ul>
+ * 
+ * <p><strong>Usage recommandé :</strong> Utiliser cette exception pour des validations
+ * métier complexes qui ne peuvent pas être exprimées par des annotations de validation.</p>
+ * 
+ * <p><strong>Gestion :</strong> Capturée par {@link com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler}
+ * et transformée en réponse HTTP 400 (Bad Request) avec message d'erreur détaillé.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler
  */
 public class InvalidRequestException extends RuntimeException {
     
+    /**
+     * Construit une nouvelle exception avec le message spécifié.
+     * 
+     * @param message le message d'erreur décrivant la validation échouée
+     */
     public InvalidRequestException(String message) {
         super(message);
     }
     
+    /**
+     * Construit une nouvelle exception avec le message et la cause spécifiés.
+     * 
+     * @param message le message d'erreur décrivant la validation échouée
+     * @param cause la cause sous-jacente de l'exception
+     */
     public InvalidRequestException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/ecclesiaflow/web/exception/MemberAlreadyConfirmedException.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/MemberAlreadyConfirmedException.java
@@ -1,14 +1,59 @@
 package com.ecclesiaflow.web.exception;
 
 /**
- * Exception lancée lorsqu'on tente de confirmer un membre déjà confirmé
+ * Exception levée lors d'une tentative de confirmation d'un membre déjà confirmé.
+ * <p>
+ * Cette exception est utilisée pour prévenir les tentatives de double confirmation
+ * d'un compte membre. Elle fait partie du système de sécurité pour maintenir
+ * l'intégrité des états de confirmation et éviter les opérations redondantes.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Exception métier - Gestion des états de confirmation</p>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Tentative de confirmation avec un code valide sur un compte déjà confirmé</li>
+ *   <li>Utilisation multiple du même lien de confirmation</li>
+ *   <li>Tentatives de re-confirmation par l'utilisateur</li>
+ *   <li>Protection contre les attaques de replay</li>
+ * </ul>
+ * 
+ * <p><strong>Logique métier :</strong></p>
+ * <ul>
+ *   <li>Vérification de l'état {@code confirmed} du membre avant traitement</li>
+ *   <li>Prévention des modifications d'état incohérentes</li>
+ *   <li>Maintien de l'idempotence des opérations de confirmation</li>
+ * </ul>
+ * 
+ * <p><strong>Comportement attendu :</strong> L'utilisateur est informé que son compte
+ * est déjà confirmé et peut procéder à la connexion.</p>
+ * 
+ * <p><strong>Gestion :</strong> Capturée par {@link com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler}
+ * et transformée en réponse HTTP 409 (Conflict) avec message d'information.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.business.services.MemberConfirmationService
+ * @see com.ecclesiaflow.io.entities.Member#isConfirmed()
+ * @see com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler
  */
 public class MemberAlreadyConfirmedException extends RuntimeException {
     
+    /**
+     * Construit une nouvelle exception avec le message spécifié.
+     * 
+     * @param message le message d'erreur décrivant la tentative de double confirmation
+     */
     public MemberAlreadyConfirmedException(String message) {
         super(message);
     }
     
+    /**
+     * Construit une nouvelle exception avec le message et la cause spécifiés.
+     * 
+     * @param message le message d'erreur décrivant la tentative de double confirmation
+     * @param cause la cause sous-jacente de l'exception
+     */
     public MemberAlreadyConfirmedException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/ecclesiaflow/web/exception/MemberNotFoundException.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/MemberNotFoundException.java
@@ -1,6 +1,35 @@
 package com.ecclesiaflow.web.exception;
 
+/**
+ * Exception levée lorsqu'un membre demandé n'existe pas dans le système.
+ * <p>
+ * Cette exception est utilisée dans les opérations de recherche, mise à jour,
+ * suppression ou confirmation de membres lorsque l'identifiant fourni ne
+ * correspond à aucun membre en base de données.
+ * </p>
+ * 
+ * <p><strong>Cas d'utilisation typiques :</strong></p>
+ * <ul>
+ *   <li>Recherche d'un membre par ID inexistant</li>
+ *   <li>Tentative de mise à jour d'un membre supprimé</li>
+ *   <li>Processus de confirmation sur un membre inexistant</li>
+ *   <li>Opérations administratives sur des comptes invalides</li>
+ * </ul>
+ * 
+ * <p><strong>Gestion :</strong> Capturée par {@link com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler}
+ * et transformée en réponse HTTP 404 avec message d'erreur standardisé.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler
+ */
 public class MemberNotFoundException extends RuntimeException {
+    
+    /**
+     * Construit une nouvelle exception avec le message spécifié.
+     * 
+     * @param message le message d'erreur détaillant le membre non trouvé
+     */
     public MemberNotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/com/ecclesiaflow/web/exception/PasswordResetEmailException.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/PasswordResetEmailException.java
@@ -1,6 +1,57 @@
 package com.ecclesiaflow.web.exception;
 
+/**
+ * Exception spécialisée levée lors d'un échec d'envoi d'email de réinitialisation de mot de passe.
+ * <p>
+ * Cette exception hérite de {@link EmailSendingException} et est spécifiquement utilisée
+ * pour les erreurs d'envoi des emails de réinitialisation de mot de passe dans le
+ * contexte de récupération de compte ou de changement de mot de passe.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Exception technique spécialisée - Emails de réinitialisation</p>
+ * 
+ * <p><strong>Contexte d'utilisation :</strong></p>
+ * <ul>
+ *   <li>Échec d'envoi de l'email de réinitialisation de mot de passe</li>
+ *   <li>Problèmes de template d'email de récupération</li>
+ *   <li>Erreurs lors de la génération de liens de réinitialisation</li>
+ *   <li>Problèmes de sécurité ou de tokens de réinitialisation</li>
+ * </ul>
+ * 
+ * <p><strong>Contenu de l'email concerné :</strong></p>
+ * <ul>
+ *   <li>Lien sécurisé de réinitialisation de mot de passe</li>
+ *   <li>Instructions de sécurité</li>
+ *   <li>Durée de validité du lien</li>
+ *   <li>Informations de contact pour assistance</li>
+ * </ul>
+ * 
+ * <p><strong>Impact sur le flux utilisateur :</strong></p>
+ * <ul>
+ *   <li>L'utilisateur ne reçoit pas le lien de réinitialisation</li>
+ *   <li>Possibilité de nouvelle tentative de réinitialisation</li>
+ *   <li>Support manuel nécessaire en cas de problème persistant</li>
+ * </ul>
+ * 
+ * <p><strong>Sécurité :</strong> Les échecs d'envoi ne doivent pas révéler
+ * l'existence ou non d'un compte utilisateur.</p>
+ * 
+ * <p><strong>Gestion :</strong> Hérite de la gestion de {@link EmailSendingException}
+ * avec logging spécifique aux emails de réinitialisation.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see EmailSendingException
+ * @see com.ecclesiaflow.business.services.impl.EmailServiceImpl#sendPasswordResetEmail
+ */
 public class PasswordResetEmailException extends EmailSendingException {
+    
+    /**
+     * Construit une nouvelle exception avec le message et la cause spécifiés.
+     * 
+     * @param message le message d'erreur décrivant le problème d'envoi de réinitialisation
+     * @param cause la cause sous-jacente de l'exception (ex: MailException)
+     */
     public PasswordResetEmailException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/ecclesiaflow/web/exception/WelcomeEmailException.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/WelcomeEmailException.java
@@ -1,6 +1,54 @@
 package com.ecclesiaflow.web.exception;
 
+/**
+ * Exception spécialisée levée lors d'un échec d'envoi d'email de bienvenue.
+ * <p>
+ * Cette exception hérite de {@link EmailSendingException} et est spécifiquement utilisée
+ * pour les erreurs d'envoi des emails de bienvenue envoyés aux membres après
+ * confirmation réussie de leur inscription.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Exception technique spécialisée - Emails de bienvenue</p>
+ * 
+ * <p><strong>Contexte d'utilisation :</strong></p>
+ * <ul>
+ *   <li>Échec d'envoi de l'email de bienvenue après confirmation réussie</li>
+ *   <li>Problèmes de template d'email de bienvenue</li>
+ *   <li>Erreurs lors de la personnalisation du contenu de bienvenue</li>
+ *   <li>Problèmes de formatage ou de contenu de l'email</li>
+ * </ul>
+ * 
+ * <p><strong>Contenu de l'email concerné :</strong></p>
+ * <ul>
+ *   <li>Message de bienvenue personnalisé</li>
+ *   <li>Informations sur les prochaines étapes</li>
+ *   <li>Liens vers les ressources de l'application</li>
+ *   <li>Informations de contact et support</li>
+ * </ul>
+ * 
+ * <p><strong>Impact sur le flux utilisateur :</strong></p>
+ * <ul>
+ *   <li>La confirmation est réussie mais pas d'email de bienvenue</li>
+ *   <li>L'utilisateur peut continuer normalement</li>
+ *   <li>Impact moindre sur l'expérience utilisateur</li>
+ * </ul>
+ * 
+ * <p><strong>Gestion :</strong> Hérite de la gestion de {@link EmailSendingException}
+ * avec logging spécifique aux emails de bienvenue.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see EmailSendingException
+ * @see com.ecclesiaflow.business.services.impl.EmailServiceImpl#sendWelcomeEmail
+ */
 public class WelcomeEmailException extends EmailSendingException {
+    
+    /**
+     * Construit une nouvelle exception avec le message et la cause spécifiés.
+     * 
+     * @param message le message d'erreur décrivant le problème d'envoi de bienvenue
+     * @param cause la cause sous-jacente de l'exception (ex: MailException)
+     */
     public WelcomeEmailException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/ecclesiaflow/web/exception/advices/EmailExceptionHandler.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/advices/EmailExceptionHandler.java
@@ -10,30 +10,104 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 
 import java.time.LocalDateTime;
 
+/**
+ * Gestionnaire d'exceptions spécialisé pour les erreurs liées à l'envoi d'emails.
+ * <p>
+ * Cette classe {@code @ControllerAdvice} capture et traite spécifiquement les exceptions
+ * d'envoi d'email, fournissant des réponses d'erreur appropriées et un logging détaillé
+ * pour le diagnostic des problèmes de messagerie.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Gestionnaire d'exceptions spécialisé - Emails</p>
+ * 
+ * <p><strong>Exceptions gérées :</strong></p>
+ * <ul>
+ *   <li>{@link ConfirmationEmailException} - Erreurs d'envoi de confirmation</li>
+ *   <li>{@link WelcomeEmailException} - Erreurs d'envoi de bienvenue</li>
+ *   <li>{@link PasswordResetEmailException} - Erreurs d'envoi de réinitialisation</li>
+ *   <li>{@link EmailSendingException} - Erreurs génériques d'envoi</li>
+ * </ul>
+ * 
+ * <p><strong>Stratégie de gestion :</strong></p>
+ * <ul>
+ *   <li>Toutes les erreurs d'email retournent HTTP 500 (Internal Server Error)</li>
+ *   <li>Messages d'erreur spécifiques selon le type d'email</li>
+ *   <li>Inclusion des détails techniques pour le debugging</li>
+ *   <li>Logging automatique des exceptions pour monitoring</li>
+ * </ul>
+ * 
+ * <p><strong>Sécurité :</strong> Les détails techniques sont inclus dans les réponses
+ * pour faciliter le debugging, mais ne révèlent pas d'informations sensibles.</p>
+ * 
+ * <p><strong>Intégration :</strong> Fonctionne en complément de {@link GlobalExceptionHandler}
+ * avec une priorité plus élevée pour les exceptions d'email spécifiques.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see GlobalExceptionHandler
+ * @see com.ecclesiaflow.business.services.impl.EmailServiceImpl
+ */
 @ControllerAdvice
 public class EmailExceptionHandler {
 
+    /**
+     * Gère les exceptions d'envoi d'email de confirmation d'inscription.
+     * 
+     * @param ex l'exception de confirmation email capturée
+     * @param request la requête HTTP qui a causé l'exception
+     * @return réponse d'erreur HTTP 500 avec détails spécifiques
+     */
     @ExceptionHandler(ConfirmationEmailException.class)
     public ResponseEntity<ErrorResponse> handleConfirmationEmailException(ConfirmationEmailException ex, HttpServletRequest request) {
         return buildError(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur lors de l'envoi de l'email de confirmation.", request.getRequestURI(), ex);
     }
 
+    /**
+     * Gère les exceptions d'envoi d'email de bienvenue.
+     * 
+     * @param ex l'exception de bienvenue email capturée
+     * @param request la requête HTTP qui a causé l'exception
+     * @return réponse d'erreur HTTP 500 avec détails spécifiques
+     */
     @ExceptionHandler(WelcomeEmailException.class)
     public ResponseEntity<ErrorResponse> handleWelcomeEmailException(WelcomeEmailException ex, HttpServletRequest request) {
         return buildError(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur lors de l'envoi de l'email de bienvenue.", request.getRequestURI(), ex);
     }
 
+    /**
+     * Gère les exceptions d'envoi d'email de réinitialisation de mot de passe.
+     * 
+     * @param ex l'exception de réinitialisation email capturée
+     * @param request la requête HTTP qui a causé l'exception
+     * @return réponse d'erreur HTTP 500 avec détails spécifiques
+     */
     @ExceptionHandler(PasswordResetEmailException.class)
     public ResponseEntity<ErrorResponse> handlePasswordResetEmailException(PasswordResetEmailException ex, HttpServletRequest request) {
         return buildError(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur lors de l'envoi de l'email de réinitialisation de mot de passe.", request.getRequestURI(), ex);
     }
 
+    /**
+     * Gère les exceptions génériques d'envoi d'email (catch-all).
+     * 
+     * @param ex l'exception d'envoi email générique capturée
+     * @param request la requête HTTP qui a causé l'exception
+     * @return réponse d'erreur HTTP 500 avec message générique
+     */
     @ExceptionHandler(EmailSendingException.class)
     public ResponseEntity<ErrorResponse> handleEmailSendingException(EmailSendingException ex, HttpServletRequest request) {
         // Catch-all pour toute autre exception d'email non spécifique
         return buildError(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur lors de l'envoi de l'email.", request.getRequestURI(), ex);
     }
 
+    /**
+     * Construit une réponse d'erreur standardisée pour les exceptions d'email.
+     * 
+     * @param status le statut HTTP à retourner
+     * @param message le message d'erreur utilisateur
+     * @param path le chemin de la requête qui a causé l'erreur
+     * @param ex l'exception source pour les détails techniques
+     * @return réponse d'erreur formatée avec {@link ErrorResponse}
+     */
     private ResponseEntity<ErrorResponse> buildError(HttpStatus status, String message, String path, Exception ex) {
         ErrorResponse error = new ErrorResponse(
                 LocalDateTime.now(),

--- a/src/main/java/com/ecclesiaflow/web/exception/advices/GlobalExceptionHandler.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/advices/GlobalExceptionHandler.java
@@ -19,6 +19,64 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Gestionnaire global d'exceptions pour l'API REST EcclesiaFlow Members Module.
+ * <p>
+ * Cette classe centralise la gestion de toutes les exceptions levées par les contrôleurs
+ * et les transforme en réponses HTTP standardisées avec le format {@link ApiErrorResponse}.
+ * Utilise le pattern @RestControllerAdvice de Spring pour intercepter les exceptions
+ * de manière transversale.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Aspect transversal - Gestion centralisée des erreurs</p>
+ * 
+ * <p><strong>Responsabilités principales :</strong></p>
+ * <ul>
+ *   <li>Interception et transformation des exceptions métier en réponses HTTP</li>
+ *   <li>Standardisation du format des erreurs avec {@link ApiErrorResponse}</li>
+ *   <li>Gestion détaillée des erreurs de validation Bean Validation</li>
+ *   <li>Mapping approprié des codes de statut HTTP selon le type d'erreur</li>
+ *   <li>Logging et traçabilité des erreurs (implicite via Spring)</li>
+ * </ul>
+ * 
+ * <p><strong>Types d'exceptions gérées :</strong></p>
+ * <ul>
+ *   <li>{@link MethodArgumentNotValidException} - Erreurs de validation Bean Validation (400)</li>
+ *   <li>{@link ConstraintViolationException} - Violations de contraintes (400)</li>
+ *   <li>{@link HttpMessageNotReadableException} - JSON mal formé (400)</li>
+ *   <li>{@link MemberNotFoundException} - Membre non trouvé (404)</li>
+ *   <li>{@link InvalidConfirmationCodeException} - Code de confirmation invalide (400)</li>
+ *   <li>{@link MemberAlreadyConfirmedException} - Membre déjà confirmé (409)</li>
+ *   <li>{@link IllegalArgumentException} - Arguments invalides (400)</li>
+ *   <li>{@link Exception} - Erreurs génériques (500)</li>
+ * </ul>
+ * 
+ * <p><strong>Format de réponse standardisé :</strong></p>
+ * <pre>{@code
+ * {
+ *   "timestamp": "2024-01-15T10:30:00",
+ *   "status": 400,
+ *   "error": "Bad Request",
+ *   "message": "Erreur de validation des données",
+ *   "path": "/ecclesiaflow/members",
+ *   "errors": [
+ *     {
+ *       "message": "Le nom est obligatoire",
+ *       "path": "firstName",
+ *       "type": "validation",
+ *       "code": "NotBlank"
+ *     }
+ *   ]
+ * }
+ * }</pre>
+ * 
+ * <p><strong>Garanties :</strong> Gestion exhaustive, format cohérent, codes HTTP appropriés.</p>
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see ApiErrorResponse
+ * @see ValidationError
+ */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 

--- a/src/main/java/com/ecclesiaflow/web/exception/model/ApiErrorResponse.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/model/ApiErrorResponse.java
@@ -8,6 +8,50 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Record représentant une réponse d'erreur standardisée avec support des erreurs de validation.
+ * <p>
+ * Cette classe étend le concept de {@link com.ecclesiaflow.web.dto.ErrorResponse} en ajoutant
+ * la capacité de gérer des erreurs de validation détaillées. Utilisée principalement par
+ * {@link com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler} pour les erreurs
+ * de validation Bean Validation et les erreurs métier complexes.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Modèle de réponse d'erreur avancée</p>
+ * 
+ * <p><strong>Fonctionnalités :</strong></p>
+ * <ul>
+ *   <li>Informations d'erreur de base (timestamp, status, message, path)</li>
+ *   <li>Liste détaillée des erreurs de validation</li>
+ *   <li>Builder pattern pour construction flexible</li>
+ *   <li>Sérialisation JSON optimisée (exclusion des champs null)</li>
+ *   <li>Documentation OpenAPI intégrée</li>
+ * </ul>
+ * 
+ * <p><strong>Cas d'utilisation :</strong></p>
+ * <ul>
+ *   <li>Erreurs de validation Bean Validation (@Valid)</li>
+ *   <li>Erreurs de validation métier complexes</li>
+ *   <li>Erreurs avec détails multiples</li>
+ *   <li>Documentation API avec exemples détaillés</li>
+ * </ul>
+ * 
+ * <p><strong>Avantages du record :</strong> Immutabilité, equals/hashCode automatiques,
+ * constructeur compact avec validation, sérialisation JSON native.</p>
+ * 
+ * @param timestamp Horodatage de l'erreur
+ * @param status Code de statut HTTP
+ * @param error Type d'erreur HTTP
+ * @param message Message d'erreur principal
+ * @param path Chemin de la requête
+ * @param errors Liste des erreurs de validation détaillées
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see ValidationError
+ * @see com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler
+ * @see com.ecclesiaflow.web.dto.ErrorResponse
+ */
 @Schema(description = "Réponse d'erreur standard de l'API")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiErrorResponse(
@@ -35,10 +79,22 @@ public record ApiErrorResponse(
         }
     }
 
+    /**
+     * Crée un nouveau builder pour construire une ApiErrorResponse.
+     * 
+     * @return nouvelle instance de builder
+     */
     public static ApiErrorResponseBuilder builder() {
         return new ApiErrorResponseBuilder();
     }
 
+    /**
+     * Builder pour construire une ApiErrorResponse de manière fluide.
+     * <p>
+     * Permet la construction étape par étape d'une réponse d'erreur avec
+     * validation automatique et valeurs par défaut appropriées.
+     * </p>
+     */
     public static class ApiErrorResponseBuilder {
         private LocalDateTime timestamp = LocalDateTime.now();
         private int status;
@@ -47,31 +103,66 @@ public record ApiErrorResponse(
         private String path;
         private List<ValidationError> errors = new ArrayList<>();
 
+        /**
+         * Définit le code de statut HTTP.
+         * 
+         * @param status le code de statut HTTP (400, 404, 500, etc.)
+         * @return ce builder pour chaînage
+         */
         public ApiErrorResponseBuilder status(int status) {
             this.status = status;
             return this;
         }
 
+        /**
+         * Définit le type d'erreur HTTP.
+         * 
+         * @param error le type d'erreur ("Bad Request", "Not Found", etc.)
+         * @return ce builder pour chaînage
+         */
         public ApiErrorResponseBuilder error(String error) {
             this.error = error;
             return this;
         }
 
+        /**
+         * Définit le message d'erreur principal.
+         * 
+         * @param message le message d'erreur descriptif
+         * @return ce builder pour chaînage
+         */
         public ApiErrorResponseBuilder message(String message) {
             this.message = message;
             return this;
         }
 
+        /**
+         * Définit le chemin de la requête qui a causé l'erreur.
+         * 
+         * @param path le chemin de la requête HTTP
+         * @return ce builder pour chaînage
+         */
         public ApiErrorResponseBuilder path(String path) {
             this.path = path;
             return this;
         }
 
+        /**
+         * Ajoute une erreur de validation à la liste.
+         * 
+         * @param error l'erreur de validation à ajouter
+         * @return ce builder pour chaînage
+         */
         public ApiErrorResponseBuilder addValidationError(ValidationError error) {
             this.errors.add(error);
             return this;
         }
 
+        /**
+         * Construit l'ApiErrorResponse finale.
+         * 
+         * @return nouvelle instance d'ApiErrorResponse avec les paramètres définis
+         */
         public ApiErrorResponse build() {
             return new ApiErrorResponse(timestamp, status, error, message, path, errors);
         }

--- a/src/main/java/com/ecclesiaflow/web/exception/model/ValidationError.java
+++ b/src/main/java/com/ecclesiaflow/web/exception/model/ValidationError.java
@@ -2,6 +2,52 @@ package com.ecclesiaflow.web.exception.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+/**
+ * Record représentant le détail d'une erreur de validation spécifique.
+ * <p>
+ * Cette classe encapsule toutes les informations nécessaires pour décrire
+ * précisément une erreur de validation, incluant le contexte, la localisation
+ * et les détails techniques. Utilisée dans {@link ApiErrorResponse} pour
+ * fournir des informations détaillées sur les erreurs de validation.
+ * </p>
+ * 
+ * <p><strong>Rôle architectural :</strong> Modèle de détail d'erreur de validation</p>
+ * 
+ * <p><strong>Informations capturées :</strong></p>
+ * <ul>
+ *   <li>Message d'erreur localisé pour l'utilisateur</li>
+ *   <li>Chemin du champ en erreur (notation pointée)</li>
+ *   <li>Type d'erreur (validation, type, format, etc.)</li>
+ *   <li>Valeurs attendues vs reçues pour comparaison</li>
+ *   <li>Code d'erreur standardisé pour traitement automatique</li>
+ *   <li>Position dans le document (ligne/colonne) si applicable</li>
+ * </ul>
+ * 
+ * <p><strong>Cas d'utilisation :</strong></p>
+ * <ul>
+ *   <li>Erreurs de validation Bean Validation (@NotNull, @Size, etc.)</li>
+ *   <li>Erreurs de désérialisation JSON</li>
+ *   <li>Erreurs de validation métier avec localisation précise</li>
+ *   <li>Debugging et diagnostic des problèmes de validation</li>
+ * </ul>
+ * 
+ * <p><strong>Format du chemin :</strong> Notation pointée (ex: "user.address.street")
+ * pour identifier précisément le champ en erreur dans des structures imbriquées.</p>
+ * 
+ * @param message Message d'erreur localisé
+ * @param path Chemin du champ en erreur (notation pointée)
+ * @param type Type d'erreur (validation, type, format, etc.)
+ * @param expected Valeur ou type attendu
+ * @param received Valeur reçue qui a causé l'erreur
+ * @param code Code d'erreur standardisé
+ * @param line Numéro de ligne dans le document source (optionnel)
+ * @param column Numéro de colonne dans le document source (optionnel)
+ * 
+ * @author EcclesiaFlow Team
+ * @since 1.0.0
+ * @see ApiErrorResponse
+ * @see com.ecclesiaflow.web.exception.advices.GlobalExceptionHandler
+ */
 @Schema(description = "Détail d'une erreur de validation")
 public record ValidationError(
     @Schema(description = "Message d'erreur", example = "Type invalide")


### PR DESCRIPTION
- Add comprehensive JavaDoc for core classes (EmailExceptionHandler, ApiErrorResponse, ValidationError, MemberPasswordController, WebClientConfig, BusinessOperationLoggingAspect)
- Add OpenAPI annotations to MemberPasswordController with full API documentation
- Remove redundant JavaDoc comments from controllers (OpenAPI provides better API docs)
- Standardize documentation format across all modules